### PR TITLE
Signup honesty (#129), HMAC api-key hashing (#124), and SolanaSmartAgent doc cleanup

### DIFF
--- a/.changeset/api-key-hmac-hashing.md
+++ b/.changeset/api-key-hmac-hashing.md
@@ -1,0 +1,8 @@
+---
+"@pincerpay/db": minor
+"@pincerpay/onboarding": patch
+---
+
+Hash API keys with HMAC-SHA256 + pepper (parity with `cli_sessions`).
+
+`@pincerpay/db` adds shared key-hashing helpers (`hashNewApiKey`, `apiKeyHashHmac`, `apiKeyHashSha256`, `getApiKeyPepper`) and a new `api_keys.key_hash_hmac` column (migration `0004`; the legacy `key_hash` column is now nullable). New API keys are hashed with HMAC when `TOKEN_PEPPER` is configured and fall back to legacy SHA-256 otherwise; verification accepts both during the migration window. `@pincerpay/onboarding` now mints keys through the shared helper so bootstrapped merchants get HMAC-hashed keys.

--- a/.changeset/remove-solana-smart-agent-docs.md
+++ b/.changeset/remove-solana-smart-agent-docs.md
@@ -1,0 +1,8 @@
+---
+"@pincerpay/core": minor
+"@pincerpay/agent": patch
+---
+
+Remove orphaned `SolanaSmartAgent` references.
+
+`SolanaSmartAgent` and its implementation were removed from the agent SDK during the slim launch, but the documentation and a dangling type were left behind. `@pincerpay/core` drops the now-dead `SolanaSmartAgentConfig` type export, and the `@pincerpay/agent` README no longer documents the removed class, its methods, or its config. The documented surface now matches what actually ships (`PincerPayAgent`).

--- a/apps/dashboard/content/docs/agent-sdk.md
+++ b/apps/dashboard/content/docs/agent-sdk.md
@@ -120,57 +120,6 @@ const { date, amount } = agent.getDailySpend();
 console.log(`Spent ${amount} base units on ${date}`);
 ```
 
-## Solana Smart Agent (Advanced)
-
-For agents using Squads Protocol smart accounts with on-chain spending limits. Smart Accounts can be created and managed from the PincerPay dashboard (connect your wallet, set limits, no external Squads configuration needed).
-
-```typescript
-import { SolanaSmartAgent } from "@pincerpay/agent";
-
-const agent = await SolanaSmartAgent.create({
-  chains: ["solana"],
-  solanaPrivateKey: process.env.AGENT_SOLANA_KEY!,
-  smartAccountIndex: 0,
-  spendingLimitIndex: 0,
-});
-
-// Check on-chain spending policy before payment
-const policy = await agent.checkOnChainPolicy("100000");
-if (policy.allowed) {
-  const response = await agent.fetch("https://api.example.com/data");
-}
-
-// Direct on-chain settlement (bypasses x402 for Solana-native)
-const result = await agent.settleDirectly("MERCHANT_ID", "100000");
-```
-
-### Building Squads Instructions Programmatically
-
-If you need to manage Smart Accounts from code instead of the dashboard:
-
-```typescript
-// Build a createSmartAccount instruction
-const createIx = await agent.buildCreateSmartAccountInstruction({
-  members: [agentAddress, operatorAddress],
-  threshold: 1,
-});
-
-// Build an addSpendingLimit instruction
-const addLimitIx = await agent.buildAddSpendingLimitInstruction({
-  mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC mainnet
-  amount: 10_000_000n,  // 10 USDC
-  period: 1,            // 0=OneTime, 1=Daily, 2=Weekly, 3=Monthly
-  authority: operatorAddress,
-});
-
-// Build a revokeSpendingLimit instruction
-const revokeIx = await agent.buildRevokeSpendingLimitInstruction({
-  authority: operatorAddress,
-});
-```
-
-These return Solana instructions that you sign and send with your own transaction infrastructure.
-
 ## Environment Variables
 
 | Variable | Required | Description |

--- a/apps/dashboard/content/docs/quickstart-agent.md
+++ b/apps/dashboard/content/docs/quickstart-agent.md
@@ -227,7 +227,7 @@ console.log(`EVM: ${agent.evmAddress}`);
 ## Next Steps
 
 - [Interactive Demo](https://demo.pincerpay.com/playground) to experiment with spending policies, error scenarios, and Smart Accounts
-- [Agent SDK Reference](/docs/agent-sdk) for the full API including `SolanaSmartAgent`
+- [Agent SDK Reference](/docs/agent-sdk) for the full API
 - [Weather Agent Example](/docs/example-agent-weather) for a complete agent with spending policies
 - [Merchant Quickstart](/docs/quickstart-merchant) to build your own paywalled API
 - [Testing Guide](/docs/testing) for devnet setup and transaction verification

--- a/apps/dashboard/src/app/dashboard/settings/actions.ts
+++ b/apps/dashboard/src/app/dashboard/settings/actions.ts
@@ -1,9 +1,9 @@
 "use server";
 
-import { createHash, randomBytes } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import { getDb } from "@/lib/db";
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { merchants, apiKeys, type Environment } from "@pincerpay/db";
+import { merchants, apiKeys, hashNewApiKey, type Environment } from "@pincerpay/db";
 import { eq, and } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { API_KEY_PREFIX_LENGTH } from "@pincerpay/core";
@@ -86,12 +86,13 @@ export async function createApiKey(label: string, environment: Environment = "li
 
   const prefixWord = environment === "test" ? "pp_test_" : "pp_live_";
   const rawKey = `${prefixWord}${randomBytes(32).toString("hex")}`;
-  const keyHash = createHash("sha256").update(rawKey).digest("hex");
+  const { keyHash, keyHashHmac } = hashNewApiKey(rawKey);
   const prefix = rawKey.slice(0, API_KEY_PREFIX_LENGTH);
 
   await db.insert(apiKeys).values({
     merchantId: merchant.id,
     keyHash,
+    keyHashHmac,
     prefix,
     label,
     environment,

--- a/apps/facilitator/.env.example
+++ b/apps/facilitator/.env.example
@@ -53,6 +53,13 @@ SUPABASE_URL=https://[PROJECT].supabase.co
 # Supabase publishable / anon key (sb_publishable_*).
 SUPABASE_PUBLISHABLE_KEY=
 
+# Set to true ONLY once the Supabase project has a working SMTP provider
+# configured (Project Settings → Auth → SMTP; Resend is free up to 3k/mo).
+# Supabase's built-in email service silently drops most mail, so while this is
+# false /v1/onboarding/auth/signup returns 503 email_delivery_unavailable
+# instead of falsely reporting that a verification code was sent.
+SUPABASE_SMTP_CONFIGURED=false
+
 # ─── OFAC compliance (optional) ───
 # When enabled, settlement routes screen `from`/`to` addresses against the
 # Treasury SDN list. Refresh interval defaults to 24h.

--- a/apps/facilitator/scripts/api-keys-migrate-cleanup.mts
+++ b/apps/facilitator/scripts/api-keys-migrate-cleanup.mts
@@ -1,0 +1,107 @@
+import { parseArgs } from "node:util";
+import { and, eq, isNull, lt } from "drizzle-orm";
+import { createDb, apiKeys, auditEvents } from "@pincerpay/db";
+
+/**
+ * #124 cutover cleanup. Revokes any still-active API key that was minted with
+ * the legacy SHA-256 scheme (i.e. `key_hash_hmac IS NULL`) and is older than
+ * the cutover window. New keys carry an HMAC hash, so after a long enough
+ * migration window every legitimately-used key has been rotated to HMAC; the
+ * stragglers revoked here are stale credentials.
+ *
+ * Run AFTER the HMAC-minting code has been deployed for the full window
+ * (default 60 days). Always do a --dry-run first.
+ *
+ * Usage:
+ *   DATABASE_URL=postgresql://... pnpm tsx apps/facilitator/scripts/api-keys-migrate-cleanup.mts [--days 60] [--dry-run]
+ */
+
+const DEFAULT_WINDOW_DAYS = 60;
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+async function main() {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      days: { type: "string", default: String(DEFAULT_WINDOW_DAYS) },
+      "dry-run": { type: "boolean", default: false },
+    },
+    strict: true,
+  });
+
+  const url = process.env.DATABASE_URL;
+  if (!url) fail("DATABASE_URL is not set");
+
+  const days = Number(values.days);
+  if (!Number.isFinite(days) || days < 0) fail(`--days must be a non-negative number, got "${values.days}"`);
+  const dryRun = values["dry-run"] ?? false;
+
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  const { db, close } = createDb(url);
+
+  try {
+    // Legacy = active key with no HMAC hash, created before the cutoff.
+    const stale = await db
+      .select({
+        id: apiKeys.id,
+        merchantId: apiKeys.merchantId,
+        prefix: apiKeys.prefix,
+        environment: apiKeys.environment,
+        createdAt: apiKeys.createdAt,
+      })
+      .from(apiKeys)
+      .where(
+        and(
+          eq(apiKeys.isActive, true),
+          isNull(apiKeys.keyHashHmac),
+          lt(apiKeys.createdAt, cutoff),
+        ),
+      );
+
+    console.log(
+      `Found ${stale.length} active SHA-256-only key(s) created before ${cutoff.toISOString()} (window: ${days}d).`,
+    );
+
+    for (const key of stale) {
+      console.log(`  ${key.prefix}…  env=${key.environment}  created=${key.createdAt.toISOString()}  merchant=${key.merchantId}`);
+    }
+
+    if (stale.length === 0) {
+      console.log("Nothing to revoke.");
+      return;
+    }
+
+    if (dryRun) {
+      console.log("[dry-run] no changes written.");
+      return;
+    }
+
+    for (const key of stale) {
+      await db.update(apiKeys).set({ isActive: false }).where(eq(apiKeys.id, key.id));
+      await db.insert(auditEvents).values({
+        merchantId: key.merchantId,
+        eventType: "api_key.revoked",
+        metadata: {
+          keyId: key.id,
+          prefix: key.prefix,
+          reason: "sha256_cutover",
+          migration: "#124",
+        },
+        clientName: "api-keys-migrate-cleanup",
+      });
+    }
+
+    console.log(`Revoked ${stale.length} legacy key(s) and wrote audit events.`);
+  } finally {
+    await close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/apps/facilitator/src/config.ts
+++ b/apps/facilitator/src/config.ts
@@ -55,6 +55,12 @@ const envSchema = z.object({
   SUPABASE_URL: z.string().url().optional(),
   /** Supabase publishable / anon key. Required for CLI onboarding. */
   SUPABASE_PUBLISHABLE_KEY: z.string().optional(),
+  /**
+   * Set true once the Supabase project has a working SMTP provider configured.
+   * When false, /signup returns 503 instead of falsely reporting that an OTP
+   * email was sent (Supabase's built-in email service silently drops mail).
+   */
+  SUPABASE_SMTP_CONFIGURED: z.coerce.boolean().default(false),
 }).refine(
   (data) => data.SOLANA_PRIVATE_KEY || data.KORA_RPC_URL,
   { message: "At least one of SOLANA_PRIVATE_KEY or KORA_RPC_URL is required", path: ["SOLANA_PRIVATE_KEY"] },

--- a/apps/facilitator/src/index.ts
+++ b/apps/facilitator/src/index.ts
@@ -229,7 +229,7 @@ app.route("/", createOpenApiRoute());
 // Each route is IP-rate-limited internally. Only mounts when Supabase + token
 // pepper config is present; otherwise the warning above already fired.
 if (onboardingEnabled) {
-  app.route("/", createAuthRoute(db));
+  app.route("/", createAuthRoute(db, { smtpConfigured: !!config.SUPABASE_SMTP_CONFIGURED }));
 } else {
   logger.warn({
     msg: "onboarding_disabled_missing_config",

--- a/apps/facilitator/src/lib/audit.ts
+++ b/apps/facilitator/src/lib/audit.ts
@@ -4,6 +4,7 @@ import { auditEvents } from "@pincerpay/db";
 export type AuditEventType =
   | "signup.started"
   | "signup.completed"
+  | "signup.existing_account"
   | "signup.failed"
   | "email.verified"
   | "login.completed"

--- a/apps/facilitator/src/lib/supabase-auth.ts
+++ b/apps/facilitator/src/lib/supabase-auth.ts
@@ -32,6 +32,12 @@ export interface SignupResult {
   autoConfirmed: boolean;
   /** Set when an OTP email was sent and verifyEmailOtp must be called next. */
   emailSent: boolean;
+  /**
+   * True when the email already has an account. Supabase returns a stub user
+   * with an empty `identities` array (its anti-enumeration behavior) and sends
+   * no email. Callers must NOT claim an OTP was sent in this case.
+   */
+  alreadyRegistered: boolean;
   authUserId: string | null;
   email: string;
 }
@@ -59,13 +65,20 @@ export async function signUpWithPassword(opts: {
   });
   if (error) throw new SupabaseAuthError(error.message, error.status ?? 400);
 
+  // Supabase's anti-enumeration behavior: signing up an email that already has
+  // an account returns a stub user with an empty `identities` array and sends
+  // no email. Detect it so the caller doesn't falsely report an OTP was sent.
+  const alreadyRegistered =
+    Array.isArray(data.user?.identities) && data.user.identities.length === 0;
+
   // user is null if email confirmation is required and we got back only the
   // server-side confirmation tracking. Otherwise user is set.
   const autoConfirmed = !!data.user?.email_confirmed_at;
-  const emailSent = !autoConfirmed;
+  const emailSent = !autoConfirmed && !alreadyRegistered;
   return {
     autoConfirmed,
     emailSent,
+    alreadyRegistered,
     authUserId: data.user?.id ?? null,
     email: opts.email,
   };

--- a/apps/facilitator/src/lib/tokens.ts
+++ b/apps/facilitator/src/lib/tokens.ts
@@ -1,4 +1,4 @@
-import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 
 const TOKEN_PREFIX = "pp_cli_";
 const ENTROPY_BYTES = 24;
@@ -105,13 +105,4 @@ export function parseToken(rawToken: string): ParsedToken {
     hash: hashToken(rawToken),
     prefix: rawToken.slice(0, 14),
   };
-}
-
-/**
- * Plain SHA-256 hash. Reused for backwards-compat with the existing api_keys
- * table which still uses sha256(rawKey). Only use here for completeness; new
- * code should use {@link hashToken}.
- */
-export function sha256Hex(input: string): string {
-  return createHash("sha256").update(input).digest("hex");
 }

--- a/apps/facilitator/src/middleware/auth.ts
+++ b/apps/facilitator/src/middleware/auth.ts
@@ -1,8 +1,13 @@
 import { type MiddlewareHandler } from "hono";
-import { createHash } from "node:crypto";
 import { eq, and } from "drizzle-orm";
 import { API_KEY_HEADER } from "@pincerpay/core";
-import { apiKeys, merchants } from "@pincerpay/db";
+import {
+  apiKeys,
+  merchants,
+  apiKeyHashHmac,
+  apiKeyHashSha256,
+  getApiKeyPepper,
+} from "@pincerpay/db";
 import type { Database } from "@pincerpay/db";
 import type { AppEnv } from "../env.js";
 
@@ -24,14 +29,31 @@ export function authMiddleware(db: Database): MiddlewareHandler<AppEnv> {
       return c.json({ error: "Missing API key" }, 401);
     }
 
-    const keyHash = createHash("sha256").update(apiKey).digest("hex");
     const keyPrefix = apiKey.slice(0, 12);
 
-    const [key] = await db
-      .select()
-      .from(apiKeys)
-      .where(and(eq(apiKeys.keyHash, keyHash), eq(apiKeys.isActive, true)))
-      .limit(1);
+    // Look up by HMAC first (current scheme, #124), then fall back to the legacy
+    // SHA-256 column so keys minted before the migration keep working until the
+    // cutover cleanup revokes them.
+    const pepper = getApiKeyPepper();
+    let key:
+      | typeof apiKeys.$inferSelect
+      | undefined;
+
+    if (pepper) {
+      [key] = await db
+        .select()
+        .from(apiKeys)
+        .where(and(eq(apiKeys.keyHashHmac, apiKeyHashHmac(apiKey, pepper)), eq(apiKeys.isActive, true)))
+        .limit(1);
+    }
+
+    if (!key) {
+      [key] = await db
+        .select()
+        .from(apiKeys)
+        .where(and(eq(apiKeys.keyHash, apiKeyHashSha256(apiKey)), eq(apiKeys.isActive, true)))
+        .limit(1);
+    }
 
     if (!key) {
       logger.warn({

--- a/apps/facilitator/src/routes/onboarding/api-keys.ts
+++ b/apps/facilitator/src/routes/onboarding/api-keys.ts
@@ -1,12 +1,11 @@
 import { Hono, type Context } from "hono";
 import { randomBytes } from "node:crypto";
 import { and, count, eq } from "drizzle-orm";
-import { apiKeys, merchants } from "@pincerpay/db";
+import { apiKeys, merchants, hashNewApiKey } from "@pincerpay/db";
 import type { Database, Environment } from "@pincerpay/db";
 import { API_KEY_PREFIX_LENGTH } from "@pincerpay/core";
 import type { AppEnv } from "../../env.js";
 import { audit } from "../../lib/audit.js";
-import { sha256Hex } from "../../lib/tokens.js";
 import { createApiKeySchema, sessionIdParamSchema } from "./schemas.js";
 
 const MAX_ACTIVE_KEYS_PER_MERCHANT = 50;
@@ -31,9 +30,9 @@ function clientIp(c: Context<AppEnv>): string | null {
 function newApiKey(environment: Environment) {
   const prefixWord = environment === "test" ? "pp_test_" : "pp_live_";
   const rawKey = `${prefixWord}${randomBytes(32).toString("hex")}`;
-  const keyHash = sha256Hex(rawKey);
+  const { keyHash, keyHashHmac } = hashNewApiKey(rawKey);
   const prefix = rawKey.slice(0, API_KEY_PREFIX_LENGTH);
-  return { rawKey, keyHash, prefix };
+  return { rawKey, keyHash, keyHashHmac, prefix };
 }
 
 export function createApiKeysOnboardingRoute(db: Database) {
@@ -75,12 +74,13 @@ export function createApiKeysOnboardingRoute(db: Database) {
     }
 
     const environment: Environment = parsed.data.isTest ? "test" : "live";
-    const { rawKey, keyHash, prefix } = newApiKey(environment);
+    const { rawKey, keyHash, keyHashHmac, prefix } = newApiKey(environment);
     const [created] = await db
       .insert(apiKeys)
       .values({
         merchantId,
         keyHash,
+        keyHashHmac,
         prefix,
         label: parsed.data.label,
         environment,
@@ -172,12 +172,13 @@ export function createApiKeysOnboardingRoute(db: Database) {
     if (!target) return c.json({ error: "api_key_not_found" }, 404);
 
     // Rotation preserves environment: rotating a test key produces a test key.
-    const { rawKey, keyHash, prefix } = newApiKey(target.environment);
+    const { rawKey, keyHash, keyHashHmac, prefix } = newApiKey(target.environment);
     const [created] = await db
       .insert(apiKeys)
       .values({
         merchantId,
         keyHash,
+        keyHashHmac,
         prefix,
         label: target.label,
         environment: target.environment,

--- a/apps/facilitator/src/routes/onboarding/auth.ts
+++ b/apps/facilitator/src/routes/onboarding/auth.ts
@@ -73,7 +73,13 @@ async function mintSessionForUser(opts: MintForUserOptions) {
   };
 }
 
-export function createAuthRoute(db: Database) {
+export interface AuthRouteOptions {
+  /** Whether the Supabase project has a working SMTP provider. When false,
+   * /signup fails loud rather than claiming an OTP email was sent. */
+  smtpConfigured: boolean;
+}
+
+export function createAuthRoute(db: Database, opts: AuthRouteOptions) {
   const app = new Hono<AppEnv>();
 
   // Public endpoints get tighter IP rate limits than the global facilitator rate.
@@ -112,6 +118,7 @@ export function createAuthRoute(db: Database) {
       }, logger);
 
       // If auto-confirmed (email confirmation disabled), mint a session immediately.
+      // This path needs no email, so the SMTP gate below does not apply.
       if (result.autoConfirmed && result.authUserId) {
         const session = await mintSessionForUser({
           db,
@@ -136,6 +143,39 @@ export function createAuthRoute(db: Database) {
           prefix: session.prefix,
           authUserId: result.authUserId,
         });
+      }
+
+      // From here the flow depends on an OTP email actually being delivered.
+      // If no SMTP provider is configured, Supabase silently drops the mail and
+      // the caller would wait forever. Fail loud instead of lying with a 200.
+      if (!opts.smtpConfigured) {
+        logger.error({
+          msg: "signup_email_delivery_unavailable",
+          email: parsed.data.email,
+          hint: "Configure SMTP on the Supabase project and set SUPABASE_SMTP_CONFIGURED=true.",
+        });
+        return c.json(
+          {
+            error: "email_delivery_unavailable",
+            message:
+              "Email verification is temporarily unavailable on this deployment. Please try again later or contact support.",
+          },
+          503,
+        );
+      }
+
+      // Anti-enumeration: when the email already has an account, Supabase sends
+      // no email and returns a stub user. We must not reveal that the account
+      // exists, so the response is identical to a fresh signup — but we log and
+      // audit the no-op so ops can tell real sends from silent skips.
+      if (result.alreadyRegistered) {
+        logger.warn({ msg: "signup_existing_account_noop", email: parsed.data.email });
+        await audit(db, {
+          eventType: "signup.existing_account",
+          metadata: { email: parsed.data.email },
+          clientIp: ip,
+          clientName: cName,
+        }, logger);
       }
 
       return c.json({

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -56,54 +56,6 @@ class PincerPayAgent {
 }
 ```
 
-### `SolanaSmartAgent`
-
-Extended agent with Squads SPN smart account support, on-chain spending policies, and direct settlement via the Anchor program.
-
-```typescript
-class SolanaSmartAgent extends PincerPayAgent {
-  static override async create(config: SolanaSmartAgentConfig): Promise<SolanaSmartAgent>;
-
-  // Squads PDAs (derived automatically from config)
-  get smartAccountPda(): string | undefined;
-  get settingsPda(): string | undefined;
-  get spendingLimitPda(): string | undefined;
-
-  // Direct settlement (bypasses x402, settles via Anchor program)
-  async settleDirectly(
-    merchantId: string,
-    amountBaseUnits: string,
-    options?: { facilitatorUrl?: string; apiKey?: string; network?: string }
-  ): Promise<{ success: boolean; transactionId?: string; accounts?: Record<string, string>; error?: string }>;
-
-  // On-chain policy check (optimistic pre-check against Squads spending limit)
-  async checkOnChainPolicy(
-    amountBaseUnits: string,
-    rpcUrl?: string
-  ): Promise<{ allowed: boolean; reason?: string; remainingAmount?: bigint }>;
-
-  // Instruction builders (returns Instruction, caller signs and sends)
-  async buildCreateSmartAccountInstruction(params?: {
-    members?: string[];
-    threshold?: number;
-  }): Promise<Instruction>;
-
-  async buildAddSpendingLimitInstruction(params: {
-    mint: string;
-    amount: bigint;
-    period: SpendingLimitPeriod;
-    members?: string[];
-    destinations?: string[];
-    authority: string;
-  }): Promise<Instruction>;
-
-  async buildRevokeSpendingLimitInstruction(params: {
-    authority: string;
-    rentCollector?: string;
-  }): Promise<Instruction>;
-}
-```
-
 ### Config
 
 ```typescript
@@ -113,12 +65,6 @@ interface AgentConfig {
   solanaPrivateKey?: string;       // Base58-encoded Solana keypair
   policies?: SpendingPolicy[];     // Client-side spending limits
   facilitatorUrl?: string;         // Default: https://facilitator.pincerpay.com
-}
-
-interface SolanaSmartAgentConfig extends AgentConfig {
-  settingsPda?: string;            // Override Squads Settings PDA
-  smartAccountIndex?: number;      // For PDA derivation (default: 0)
-  spendingLimitIndex?: number;     // For PDA derivation (default: 0)
 }
 
 interface SpendingPolicy {
@@ -176,49 +122,6 @@ agent.setPolicy({ maxPerTransaction: "5000000", maxPerDay: "50000000" });
 // Monitor daily spending
 const { date, amount } = agent.getDailySpend();
 console.log(`Spent ${amount} base units on ${date}`); // amount is bigint
-```
-
-### Direct settlement via Anchor program
-
-```typescript
-import { SolanaSmartAgent } from "@pincerpay/agent";
-
-const agent = await SolanaSmartAgent.create({
-  chains: ["solana"],
-  solanaPrivateKey: process.env.AGENT_SOLANA_KEY!,
-  smartAccountIndex: 0,
-  spendingLimitIndex: 0,
-});
-
-// Check on-chain spending limit before payment
-const check = await agent.checkOnChainPolicy("500000");
-if (check.allowed) {
-  const result = await agent.settleDirectly("merchant-uuid", "500000", {
-    apiKey: process.env.PINCERPAY_API_KEY!,
-  });
-}
-```
-
-### Build Squads instructions for wallet signing
-
-```typescript
-const agent = await SolanaSmartAgent.create({
-  chains: ["solana"],
-  solanaPrivateKey: process.env.AGENT_SOLANA_KEY!,
-  smartAccountIndex: 0,
-});
-
-// Build instructions -- sign and send with your wallet adapter
-const createIx = await agent.buildCreateSmartAccountInstruction({ threshold: 1 });
-const limitIx = await agent.buildAddSpendingLimitInstruction({
-  mint: usdcMintAddress,
-  amount: 10_000_000n, // 10 USDC
-  period: SpendingLimitPeriod.Day,
-  authority: walletAddress,
-});
-const revokeIx = await agent.buildRevokeSpendingLimitInstruction({
-  authority: walletAddress,
-});
 ```
 
 ## Anti-Patterns

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -148,15 +148,6 @@ export interface AgentProfile {
   updatedAt: Date;
 }
 
-export interface SolanaSmartAgentConfig extends AgentConfig {
-  /** Squads Settings PDA */
-  settingsPda?: string;
-  /** Smart Account index for PDA derivation */
-  smartAccountIndex?: number;
-  /** Spending Limit index for PDA derivation */
-  spendingLimitIndex?: number;
-}
-
 // ─── Spending Policy ───
 
 export interface SpendingPolicy {

--- a/packages/db/drizzle/0004_needy_photon.sql
+++ b/packages/db/drizzle/0004_needy_photon.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "api_keys" ALTER COLUMN "key_hash" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "api_keys" ADD COLUMN "key_hash_hmac" text;--> statement-breakpoint
+CREATE INDEX "api_keys_key_hash_hmac_idx" ON "api_keys" USING btree ("key_hash_hmac");--> statement-breakpoint
+ALTER TABLE "api_keys" ADD CONSTRAINT "api_keys_key_hash_hmac_unique" UNIQUE("key_hash_hmac");

--- a/packages/db/drizzle/meta/0004_snapshot.json
+++ b/packages/db/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1567 @@
+{
+  "id": "efef841a-8f1b-4a17-8f76-70c652c9bd32",
+  "prevId": "264e4543-6ec6-43a6-836d-f6ac192e0f61",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solana_address": {
+          "name": "solana_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smart_account_pda": {
+          "name": "smart_account_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_pda": {
+          "name": "settings_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spending_limit_pda": {
+          "name": "spending_limit_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_per_transaction": {
+          "name": "max_per_transaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_per_day": {
+          "name": "max_per_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spending_limit_index": {
+          "name": "spending_limit_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agents_merchant_id_idx": {
+          "name": "agents_merchant_id_idx",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_solana_address_idx": {
+          "name": "agents_solana_address_idx",
+          "columns": [
+            {
+              "expression": "solana_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agents_status_idx": {
+          "name": "agents_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_merchant_id_merchants_id_fk": {
+          "name": "agents_merchant_id_merchants_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash_hmac": {
+          "name": "key_hash_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Default'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'live'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_merchant_id_idx": {
+          "name": "api_keys_merchant_id_idx",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_idx": {
+          "name": "api_keys_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_key_hash_hmac_idx": {
+          "name": "api_keys_key_hash_hmac_idx",
+          "columns": [
+            {
+              "expression": "key_hash_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_merchant_env_active_idx": {
+          "name": "api_keys_merchant_env_active_idx",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"api_keys\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_merchant_id_merchants_id_fk": {
+          "name": "api_keys_merchant_id_merchants_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        },
+        "api_keys_key_hash_hmac_unique": {
+          "name": "api_keys_key_hash_hmac_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash_hmac"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_auth_user_id_created_at_idx": {
+          "name": "audit_events_auth_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_merchant_id_created_at_idx": {
+          "name": "audit_events_merchant_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_events_event_type_idx": {
+          "name": "audit_events_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_merchant_id_merchants_id_fk": {
+          "name": "audit_events_merchant_id_merchants_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_sessions": {
+      "name": "cli_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CLI'"
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip_first": {
+          "name": "client_ip_first",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip_last": {
+          "name": "client_ip_last",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'merchant:* api-keys:*'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cli_sessions_token_hash_active_idx": {
+          "name": "cli_sessions_token_hash_active_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"cli_sessions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_sessions_auth_user_id_active_idx": {
+          "name": "cli_sessions_auth_user_id_active_idx",
+          "columns": [
+            {
+              "expression": "auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"cli_sessions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_sessions_token_hash_unique": {
+          "name": "cli_sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cli_sessions_revoked_reason_valid": {
+          "name": "cli_sessions_revoked_reason_valid",
+          "value": "\"cli_sessions\".\"revoked_reason\" IS NULL OR \"cli_sessions\".\"revoked_reason\" IN ('user','admin','expired','compromised','auth_user_deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.compliance_events": {
+      "name": "compliance_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matched_list": {
+          "name": "matched_list",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "compliance_events_address_idx": {
+          "name": "compliance_events_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compliance_events_result_idx": {
+          "name": "compliance_events_result_idx",
+          "columns": [
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compliance_events_created_at_idx": {
+          "name": "compliance_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compliance_events_transaction_id_transactions_id_fk": {
+          "name": "compliance_events_transaction_id_transactions_id_fk",
+          "tableFrom": "compliance_events",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.merchants": {
+      "name": "merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supported_chains": {
+          "name": "supported_chains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "webhook_url_live": {
+          "name": "webhook_url_live",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_live": {
+          "name": "webhook_secret_live",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_url_test": {
+          "name": "webhook_url_test",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret_test": {
+          "name": "webhook_secret_test",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "on_chain_registered": {
+          "name": "on_chain_registered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merchant_pda": {
+          "name": "merchant_pda",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "merchants_auth_user_id_unique": {
+          "name": "merchants_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.paywalls": {
+      "name": "paywalls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'live'"
+        },
+        "endpoint_pattern": {
+          "name": "endpoint_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chains": {
+          "name": "chains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "paywalls_merchant_id_idx": {
+          "name": "paywalls_merchant_id_idx",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "paywalls_merchant_env_endpoint_uniq": {
+          "name": "paywalls_merchant_env_endpoint_uniq",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endpoint_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "paywalls_merchant_id_merchants_id_fk": {
+          "name": "paywalls_merchant_id_merchants_id_fk",
+          "tableFrom": "paywalls",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'live'"
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_cost": {
+          "name": "gas_cost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "gas_token": {
+          "name": "gas_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ETH'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "optimistic": {
+          "name": "optimistic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slot": {
+          "name": "slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_fee": {
+          "name": "priority_fee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compute_units": {
+          "name": "compute_units",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settlement_type": {
+          "name": "settlement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'x402'"
+        },
+        "program_nonce": {
+          "name": "program_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_merchant_id_idx": {
+          "name": "transactions_merchant_id_idx",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_tx_hash_idx": {
+          "name": "transactions_tx_hash_idx",
+          "columns": [
+            {
+              "expression": "tx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_created_at_idx": {
+          "name": "transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_merchant_chain_created_idx": {
+          "name": "transactions_merchant_chain_created_idx",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_merchant_env_created_idx": {
+          "name": "transactions_merchant_env_created_idx",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_api_key_id_idx": {
+          "name": "transactions_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_merchant_id_merchants_id_fk": {
+          "name": "transactions_merchant_id_merchants_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_api_key_id_api_keys_id_fk": {
+          "name": "transactions_api_key_id_api_keys_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transactions_agent_id_agents_id_fk": {
+          "name": "transactions_agent_id_agents_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'live'"
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_merchant_id_idx": {
+          "name": "webhook_deliveries_merchant_id_idx",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_transaction_id_idx": {
+          "name": "webhook_deliveries_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_status_idx": {
+          "name": "webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_next_retry_idx": {
+          "name": "webhook_deliveries_next_retry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_merchant_env_status_retry_idx": {
+          "name": "webhook_deliveries_merchant_env_status_retry_idx",
+          "columns": [
+            {
+              "expression": "merchant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_merchant_id_merchants_id_fk": {
+          "name": "webhook_deliveries_merchant_id_merchants_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "merchants",
+          "columnsFrom": [
+            "merchant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_transaction_id_transactions_id_fk": {
+          "name": "webhook_deliveries_transaction_id_transactions_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.environment": {
+      "name": "environment",
+      "schema": "public",
+      "values": [
+        "live",
+        "test"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777766243385,
       "tag": "0003_environment_scoping",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1779841729702,
+      "tag": "0004_needy_photon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/hashing.ts
+++ b/packages/db/src/hashing.ts
@@ -1,0 +1,63 @@
+import { createHash, createHmac } from "node:crypto";
+
+/**
+ * API key hashing helpers, shared by every site that mints or verifies a
+ * `pp_live_*` / `pp_test_*` key (facilitator middleware + onboarding route,
+ * dashboard server actions, CLI bootstrap).
+ *
+ * Two schemes coexist during the migration tracked in #124:
+ *   - legacy: plain SHA-256 of the raw key, stored in `api_keys.key_hash`.
+ *   - current: HMAC-SHA256 with the server pepper (the same TOKEN_PEPPER used
+ *     for cli_sessions), stored in `api_keys.key_hash_hmac`.
+ *
+ * New keys are hashed with HMAC when a pepper is available; verification tries
+ * HMAC first and falls back to SHA-256 so existing keys keep working until the
+ * cutover cleanup revokes them.
+ */
+
+/** HMAC-SHA256(pepper, rawKey) as hex. Use for all newly minted keys. */
+export function apiKeyHashHmac(rawKey: string, pepper: string): string {
+  return createHmac("sha256", pepper).update(rawKey).digest("hex");
+}
+
+/** Legacy plain SHA-256(rawKey) as hex. Kept only for fallback verification. */
+export function apiKeyHashSha256(rawKey: string): string {
+  return createHash("sha256").update(rawKey).digest("hex");
+}
+
+/** Minimum pepper length (matches the facilitator's TOKEN_PEPPER validation). */
+const MIN_PEPPER_LENGTH = 32;
+
+/**
+ * Read a usable token pepper from the environment, or null when none is
+ * configured. Callers fall back to legacy SHA-256 hashing when this is null so
+ * key creation never hard-fails in a deployment that has not yet set the pepper.
+ */
+export function getApiKeyPepper(env: NodeJS.ProcessEnv = process.env): string | null {
+  const pepper = env.TOKEN_PEPPER;
+  if (!pepper || pepper.length < MIN_PEPPER_LENGTH) return null;
+  return pepper;
+}
+
+export interface MintedApiKeyHash {
+  /** Value for `api_keys.key_hash_hmac` (null when no pepper is configured). */
+  keyHashHmac: string | null;
+  /** Value for `api_keys.key_hash` (null when hashed with HMAC). */
+  keyHash: string | null;
+}
+
+/**
+ * Compute the hash columns for a freshly minted key. Prefers HMAC when a pepper
+ * is configured; otherwise writes the legacy SHA-256 column so the key remains
+ * usable. Exactly one of the two columns is non-null.
+ */
+export function hashNewApiKey(
+  rawKey: string,
+  env: NodeJS.ProcessEnv = process.env,
+): MintedApiKeyHash {
+  const pepper = getApiKeyPepper(env);
+  if (pepper) {
+    return { keyHashHmac: apiKeyHashHmac(rawKey, pepper), keyHash: null };
+  }
+  return { keyHashHmac: null, keyHash: apiKeyHashSha256(rawKey) };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,6 +3,7 @@ import postgres from "postgres";
 import * as schema from "./schema/index.js";
 
 export * from "./schema/index.js";
+export * from "./hashing.js";
 
 export type Database = ReturnType<typeof createDb>["db"];
 

--- a/packages/db/src/schema/api-keys.ts
+++ b/packages/db/src/schema/api-keys.ts
@@ -10,8 +10,17 @@ export const apiKeys = pgTable(
     merchantId: uuid("merchant_id")
       .notNull()
       .references(() => merchants.id, { onDelete: "cascade" }),
-    /** SHA-256 hash of the full API key */
-    keyHash: text("key_hash").notNull().unique(),
+    /**
+     * Legacy plain SHA-256 hash of the full API key. Nullable: keys minted
+     * after the #124 migration store {@link keyHashHmac} instead and leave this
+     * null. Retained for verifying pre-migration keys until the cutover cleanup.
+     */
+    keyHash: text("key_hash").unique(),
+    /**
+     * HMAC-SHA256(TOKEN_PEPPER, raw_key) — parity with cli_sessions.token_hash.
+     * Null for legacy keys that predate the migration.
+     */
+    keyHashHmac: text("key_hash_hmac").unique(),
     /** First 12 chars shown to user (e.g., "pp_live_abc1" or "pp_test_abc1") */
     prefix: text("prefix").notNull(),
     label: text("label").notNull().default("Default"),
@@ -24,6 +33,7 @@ export const apiKeys = pgTable(
   (table) => [
     index("api_keys_merchant_id_idx").on(table.merchantId),
     index("api_keys_key_hash_idx").on(table.keyHash),
+    index("api_keys_key_hash_hmac_idx").on(table.keyHashHmac),
     index("api_keys_merchant_env_active_idx")
       .on(table.merchantId, table.environment, table.isActive)
       .where(sql`${table.isActive} = true`),

--- a/packages/onboarding/src/merchant.ts
+++ b/packages/onboarding/src/merchant.ts
@@ -1,6 +1,6 @@
-import { createHash, randomBytes } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import { eq, ilike } from "drizzle-orm";
-import { createDb, merchants, apiKeys, type Environment } from "@pincerpay/db";
+import { createDb, merchants, apiKeys, hashNewApiKey, type Environment } from "@pincerpay/db";
 import { API_KEY_PREFIX_LENGTH } from "@pincerpay/core";
 import type { MerchantWallets } from "./wallets.js";
 
@@ -181,12 +181,13 @@ async function mintApiKey(
 ): Promise<CreatedKey> {
   const prefixWord = environment === "test" ? "pp_test_" : "pp_live_";
   const rawKey = `${prefixWord}${randomBytes(32).toString("hex")}`;
-  const keyHash = createHash("sha256").update(rawKey).digest("hex");
+  const { keyHash, keyHashHmac } = hashNewApiKey(rawKey);
   const prefix = rawKey.slice(0, API_KEY_PREFIX_LENGTH);
 
   await db.insert(apiKeys).values({
     merchantId,
     keyHash,
+    keyHashHmac,
     prefix,
     label,
     environment,

--- a/scripts/create-api-key.mts
+++ b/scripts/create-api-key.mts
@@ -1,7 +1,7 @@
 import { parseArgs } from "node:util";
-import { createHash, randomBytes } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import { eq, ilike } from "drizzle-orm";
-import { createDb, merchants, apiKeys } from "@pincerpay/db";
+import { createDb, merchants, apiKeys, hashNewApiKey } from "@pincerpay/db";
 import { API_KEY_PREFIX_LENGTH } from "@pincerpay/core";
 
 const USAGE = `
@@ -101,7 +101,7 @@ async function createKey(opts: {
     const merchant = await resolveMerchant(db, opts.merchant);
 
     const rawKey = `pp_live_${randomBytes(32).toString("hex")}`;
-    const keyHash = createHash("sha256").update(rawKey).digest("hex");
+    const { keyHash, keyHashHmac } = hashNewApiKey(rawKey);
     const prefix = rawKey.slice(0, API_KEY_PREFIX_LENGTH);
 
     if (opts.dryRun) {
@@ -115,6 +115,7 @@ async function createKey(opts: {
     await db.insert(apiKeys).values({
       merchantId: merchant.id,
       keyHash,
+      keyHashHmac,
       prefix,
       label: opts.label,
     });


### PR DESCRIPTION
## Summary

- **#129 — signup honesty (facilitator):** `/v1/onboarding/auth/signup` no longer falsely reports `verification_email_sent`. When SMTP isn't configured (`SUPABASE_SMTP_CONFIGURED=false`) the email-dependent path returns `503 email_delivery_unavailable`; the Supabase anti-enumeration stub (already-registered email) is now detected and audited without leaking account existence.
- **#124 — HMAC-SHA256 api-key hashing:** `api_keys` now stores `key_hash_hmac` (migration `0004`; legacy `key_hash` nullable), reaching parity with `cli_sessions`. Shared helpers live in `@pincerpay/db` so all minting sites (onboarding route, dashboard action, CLI bootstrap, admin script) stay in sync. New keys use HMAC when `TOKEN_PEPPER` is set, else legacy SHA-256; auth middleware verifies HMAC-first with SHA-256 fallback. Adds `api-keys-migrate-cleanup.mts` for the post-window cutover.
- **Docs cleanup:** removed orphaned `SolanaSmartAgent` references (class was deleted in the slim launch `75a03f5` but its README/docs/`SolanaSmartAgentConfig` type were left behind).
- **Changesets** included: `@pincerpay/db` minor, `@pincerpay/onboarding` patch, `@pincerpay/core` minor, `@pincerpay/agent` patch.

## Test plan

- [x] `pnpm typecheck` — 18/18 pass (on branch and on the merged tree)
- [x] `pnpm test` — only pre-existing `e2e-solana-payment` failures (require a live Solana validator; identical on base `master`)
- [x] `pnpm changeset status` validates; no unintended major bumps
- [ ] Apply migration `0004` to environments before relying on HMAC keys
- [ ] Distribute `TOKEN_PEPPER` to dashboard + CLI runtimes (tracked in #132–#135)

https://claude.ai/code/session_01KJhKgoX3z3UU5e8iknFTzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJhKgoX3z3UU5e8iknFTzX)_