### PR TITLE
fix(deps): override fast-uri to >=3.1.2 (close 2 high CVEs in facilitator + published SDKs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       "postcss@<8.5.10": "8.5.10",
       "follow-redirects@<1.16.0": "1.16.0",
       "@hono/node-server@<1.19.13": "1.19.13",
-      "uuid@<14.0.0": "14.0.0"
+      "uuid@<14.0.0": "14.0.0",
+      "fast-uri@<3.1.2": "3.1.2"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   follow-redirects@<1.16.0: 1.16.0
   '@hono/node-server@<1.19.13': 1.19.13
   uuid@<14.0.0: 14.0.0
+  fast-uri@<3.1.2: 3.1.2
 
 importers:
 
@@ -3556,8 +3557,8 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
@@ -7915,7 +7916,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8657,7 +8658,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
 


### PR DESCRIPTION
## Summary

Closes the two **high**-severity `fast-uri` CVEs surfaced by Dependabot/`pnpm audit` that the grouped bump (#136) didn't cover. `fast-uri <3.1.2` resolves transitively in the **facilitator** and in the published **`@pincerpay/agent`** and **`@pincerpay/mcp`**; this pins it to `3.1.2` via a `pnpm` override (same pattern the repo already uses for ~19 other transitive CVEs).

- path traversal via percent-encoded dot segments (`<=3.1.0`)
- host confusion via percent-encoded authority delimiters (`<=3.1.1`)

## Audit impact

| | before #136 | after #136 | after this PR |
|---|---|---|---|
| critical | 1 | 0 | 0 |
| high | 11 | 3 | **1** |
| moderate | 22 | 13 | 13 |

The 1 remaining high is **`lodash <=4.17.23`** in the **private** `apps/dashboard` only. It has **no published fix** — the advisory cites "patched `>=4.18.0`", which doesn't exist (latest lodash is 4.17.21/`.23`). It needs a consumer-dependency upgrade or an explicit risk acceptance; not override-fixable. The remaining 13 moderate are mostly dev/transitive — can follow up if desired.

## Test plan
- [x] `pnpm install` resolves; `fast-uri` now `3.1.2` in all paths (`pnpm why -r`)
- [x] `pnpm typecheck` 18/18
- [x] `pnpm audit` high count 3 → 1 (only the unfixable lodash remains)

https://claude.ai/code/session_01KJhKgoX3z3UU5e8iknFTzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJhKgoX3z3UU5e8iknFTzX)_