### PR TITLE
docs(agents): file + assign issues to @ds1 for work needing their input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,3 +147,23 @@ Agent -> HTTP 402 Challenge -> Sign USDC Transfer -> PincerPay Facilitator -> Bl
 - `scripts/bootstrap-merchant.mts` - End-to-end CLI: wallet generation + merchant row + API key
 - `scripts/create-wallets.mts` - Wallet generation only (no DB)
 - `scripts/create-api-key.mts` - Mint a key for an existing merchant
+
+## Surfacing work that needs @ds1
+
+@ds1 may miss things buried in long chat transcripts. So whenever work is
+**blocked on @ds1** — it needs a credential/access only they have (prod
+`DATABASE_URL`, npm/Vercel/Railway/CI secrets, GitHub Actions), a decision only
+they can make, or any action only they can take — do not let it live only in
+chat. Create a GitHub issue and **assign it to `ds1`** so it shows up in their
+queue.
+
+- One consolidated issue per batch of related blockers is fine (see #140 as the
+  template): a checklist, ordered by urgency, with enough context to act without
+  scrolling back, and links to any existing tracking issues instead of
+  duplicating them.
+- Label by area/severity using the repo's existing labels (e.g. `priority: high`,
+  `infra`, `security`).
+- Note inside the issue which items are being handled without them, so the
+  assigned list is purely "needs @ds1".
+- Still summarize the blockers in chat too — the issue is the durable backstop,
+  not a replacement for telling them.


### PR DESCRIPTION
## Summary

Adds a durable working guideline to `AGENTS.md`: whenever work is **blocked on @ds1** (needs a secret/credential/access only they have, a decision only they can make, or a manual action only they can take), capture it as a GitHub issue **assigned to `ds1`** rather than leaving it buried in chat — so nothing requiring their input gets missed.

Codifies the pattern already used for #140 (consolidated, checklist, ordered by urgency, links existing trackers, notes what's being handled without them).

This is memory/preference, not an automated hook — deciding what "needs @ds1's input" requires judgment, so it lives in the agent guide rather than `settings.json`.

## Test plan
- [x] Docs-only change to `AGENTS.md`; no code affected.

https://claude.ai/code/session_01KJhKgoX3z3UU5e8iknFTzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJhKgoX3z3UU5e8iknFTzX)_