### PR TITLE
docs: HMAC api-key hashing + signup SMTP behavior (dev + agent docs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,11 +116,15 @@ Agent -> HTTP 402 Challenge -> Sign USDC Transfer -> PincerPay Facilitator -> Bl
 - `ANCHOR_PROGRAM_ID` - On-chain settlement program
 - `OFAC_ENABLED` - Enable OFAC compliance screening
 - `LOGTAIL_SOURCE_TOKEN` - Better Stack log aggregation
+- `TOKEN_PEPPER` - HMAC pepper (min 32 chars) for `cli_sessions` + API key hashing. See [Auth & secrets](#auth--secrets).
+- `SUPABASE_URL` / `SUPABASE_PUBLISHABLE_KEY` - Supabase project (required for CLI onboarding)
+- `SUPABASE_SMTP_CONFIGURED` - Set `true` only once the Supabase project has a working SMTP provider; otherwise `/v1/onboarding/auth/signup` returns `503 email_delivery_unavailable` instead of falsely reporting an OTP was sent.
 
 ### Dashboard (`apps/dashboard/.env.local`)
 - `DATABASE_URL` - PostgreSQL connection string
 - `NEXT_PUBLIC_SUPABASE_URL` - Supabase project URL
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY` - Supabase anon key
+- `TOKEN_PEPPER` - Required for the dashboard to mint HMAC API keys; **must be byte-for-byte identical** to the facilitator's value (see [Auth & secrets](#auth--secrets)).
 
 ## Conventions
 
@@ -133,6 +137,20 @@ Agent -> HTTP 402 Challenge -> Sign USDC Transfer -> PincerPay Facilitator -> Bl
 - **Branching**: `feat/description`, `fix/description`, `chore/description`
 - **CI**: GitHub Actions (typecheck, test, build)
 
+## Auth & secrets
+
+- **API keys** (`pp_live_*` / `pp_test_*`) and **CLI sessions** (`pp_cli_*`) are stored
+  hashed, never in plaintext. Both use **HMAC-SHA256 with the `TOKEN_PEPPER` server
+  pepper**. API keys carry a legacy **SHA-256 fallback** (`api_keys.key_hash`) for keys
+  minted before migration `0004`; verification tries HMAC first, then SHA-256.
+- **All services that mint API keys** (facilitator onboarding route, dashboard server
+  actions, `scripts/*` bootstrap/admin tools) must share the **same** `TOKEN_PEPPER`, or
+  the keys they create won't authenticate. Hashing goes through the shared helpers in
+  `@pincerpay/db` (`hashNewApiKey`, `apiKeyHashHmac`, `apiKeyHashSha256`, `getApiKeyPepper`) —
+  do not re-implement hashing at a mint site.
+- When `TOKEN_PEPPER` is unset, helpers fall back to legacy SHA-256 so key creation never
+  hard-fails (the key is still usable via the fallback lookup).
+
 ## Key Files
 
 - `apps/facilitator/src/index.ts` - Facilitator entry point
@@ -144,9 +162,11 @@ Agent -> HTTP 402 Challenge -> Sign USDC Transfer -> PincerPay Facilitator -> Bl
 - `packages/solana/src/kora/` - Kora gasless transaction integration
 - `packages/onboarding/src/wallets.ts` - Non-custodial BIP-39 wallet generation (Phantom + MetaMask compatible)
 - `packages/onboarding/src/merchant.ts` - Merchant + API key creation helpers
+- `packages/db/src/hashing.ts` - Shared API-key hashing helpers (HMAC + SHA-256 fallback)
 - `scripts/bootstrap-merchant.mts` - End-to-end CLI: wallet generation + merchant row + API key
 - `scripts/create-wallets.mts` - Wallet generation only (no DB)
 - `scripts/create-api-key.mts` - Mint a key for an existing merchant
+- `apps/facilitator/scripts/api-keys-migrate-cleanup.mts` - Revoke leftover SHA-256-only keys after the HMAC cutover window
 
 ## Surfacing work that needs @ds1
 

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -11,5 +11,10 @@ SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
 # Database (direct connection for Drizzle)
 DATABASE_URL=postgresql://postgres:[PASSWORD]@db.[PROJECT].supabase.co:5432/postgres
 
+# HMAC pepper for API key hashing (min 32 chars). The dashboard mints API keys,
+# so this MUST be byte-for-byte identical to the facilitator's TOKEN_PEPPER or the
+# keys it creates won't authenticate. If unset, keys fall back to legacy SHA-256.
+TOKEN_PEPPER=
+
 # Admin dashboard (Supabase Auth user ID)
 ADMIN_USER_ID=

--- a/apps/dashboard/content/docs/error-reference.md
+++ b/apps/dashboard/content/docs/error-reference.md
@@ -80,7 +80,7 @@ Invalid or deactivated API key:
 }
 ```
 
-The facilitator expects the key in the `x-pincerpay-api-key` header. Keys are validated by SHA-256 hash lookup. Only active keys pass authentication -- if you have deactivated a key in the dashboard, it will return 401 even if the key string is correct.
+The facilitator expects the key in the `x-pincerpay-api-key` header. Keys are validated by a hashed lookup — HMAC-SHA256 with a server pepper, with a legacy SHA-256 fallback during the migration window — never by storing the raw key. Only active keys pass authentication -- if you have deactivated a key in the dashboard, it will return 401 even if the key string is correct.
 
 ### 402 -- Payment Required
 

--- a/apps/dashboard/content/docs/onboarding.md
+++ b/apps/dashboard/content/docs/onboarding.md
@@ -169,8 +169,18 @@ The credentials file is corrupted. Delete `~/.pincerpay/credentials.json` and re
 **"email_not_verified"**
 You haven't completed the OTP step. Run `pincerpay signup` again with the same email — Supabase will email a fresh code.
 
+**"email_delivery_unavailable" (503 on signup)**
+The deployment has not confirmed a working email provider, so signup fails loudly
+instead of pretending a code was sent. The operator must configure SMTP on the
+Supabase project (Resend is free up to 3k/mo) and set `SUPABASE_SMTP_CONFIGURED=true`
+on the facilitator. Until then, email verification is unavailable. (Signup also
+no longer reports `verification_email_sent` for an email that already has an
+account — it stays silent to avoid leaking account existence.)
+
 **Email never arrives**
-Check spam. Recovery emails come from `noreply@<your-supabase-project>.supabase.co`. Production deployments configure a custom email sender in the Supabase dashboard.
+Check spam. Recovery emails come from `noreply@<your-supabase-project>.supabase.co`.
+Supabase's built-in email service is rate-limited and drops most mail, so production
+deployments must configure a real SMTP sender in the Supabase dashboard.
 
 ## Companion docs
 

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -67,10 +67,12 @@ function createDb(
 |---|---|---|
 | `id` | UUID | Primary key |
 | `merchantId` | UUID | FK → merchants |
-| `keyHash` | string | SHA-256 hash (unique) |
+| `keyHash` | string? | Legacy SHA-256 hash (unique). Null for keys minted with HMAC; see [API key hashing](#api-key-hashing) |
+| `keyHashHmac` | string? | HMAC-SHA256(`TOKEN_PEPPER`, key) (unique). Null for legacy keys |
 | `prefix` | string | First 12 chars for identification |
 | `label` | string | Human-readable label |
 | `isActive` | boolean | |
+| `environment` | enum | `live` or `test` — a `test` key cannot settle on a mainnet chain |
 | `createdAt` | timestamp | |
 | `lastUsedAt` | timestamp? | Updated on each API call |
 
@@ -110,6 +112,35 @@ function createDb(
 | `status` | string | active/paused/revoked |
 | `createdAt` | timestamp | |
 | `updatedAt` | timestamp | |
+
+## API key hashing
+
+`pp_live_*` / `pp_test_*` API keys are stored hashed, never in plaintext. Use the
+shared helpers so every minting/verification site stays consistent:
+
+```typescript
+import { hashNewApiKey, apiKeyHashHmac, apiKeyHashSha256, getApiKeyPepper } from "@pincerpay/db";
+
+// Mint: hashes with HMAC when TOKEN_PEPPER is set, else legacy SHA-256.
+const { keyHash, keyHashHmac } = hashNewApiKey(rawKey);
+await db.insert(apiKeys).values({ merchantId, keyHash, keyHashHmac, prefix, label, environment });
+
+// Verify: try HMAC first, fall back to legacy SHA-256.
+const pepper = getApiKeyPepper();           // string | null
+const row = pepper
+  ? await findByHmac(apiKeyHashHmac(rawKey, pepper)) ?? await findBySha256(apiKeyHashSha256(rawKey))
+  : await findBySha256(apiKeyHashSha256(rawKey));
+```
+
+- **`TOKEN_PEPPER`** — server pepper (min 32 chars), the same value used for `cli_sessions`.
+  Every service that mints keys (facilitator, dashboard, CLI/bootstrap scripts) must share the
+  **byte-for-byte identical** pepper, or HMAC lookups won't match. When unset, helpers fall back to
+  legacy SHA-256 so key creation never hard-fails.
+- **Migration `0004`** adds the nullable `key_hash_hmac` column and makes `key_hash` nullable. New
+  keys store one or the other; verification accepts both during the migration window.
+- **Cutover** — once every minting service has the pepper and enough time has passed,
+  `apps/facilitator/scripts/api-keys-migrate-cleanup.mts` revokes the leftover SHA-256-only keys
+  (`--dry-run` first; default 60-day window) and writes an audit event per revocation.
 
 ## Common Patterns
 


### PR DESCRIPTION
## Summary

Documents this session's shipped work (#124 HMAC api-key hashing, #129 signup honesty) and previously-undocumented features, across both developer- and agent-facing docs.

**Developer-facing**
- **`packages/db/README.md`** — new "API key hashing" section (`hashNewApiKey` / `apiKeyHashHmac` / `apiKeyHashSha256` / `getApiKeyPepper`), the `key_hash_hmac` column + nullable `key_hash` (migration `0004`), the `TOKEN_PEPPER` requirement, and the cutover cleanup script. Also fixed the `apiKeys` table (added `keyHashHmac`, the now-nullable `keyHash`, and the previously-undocumented `environment` column).
- **`apps/dashboard/.env.example`** — added `TOKEN_PEPPER` (must match the facilitator's, else dashboard-minted keys won't authenticate).
- **`apps/dashboard/content/docs/onboarding.md`** — documented the `503 email_delivery_unavailable` signup response + `SUPABASE_SMTP_CONFIGURED`, and the anti-enumeration silence for already-registered emails.
- **`apps/dashboard/content/docs/error-reference.md`** — corrected the stale "validated by SHA-256 hash lookup" to HMAC-first with SHA-256 fallback.

**Agent-facing**
- **`AGENTS.md`** — new "Auth & secrets" section (HMAC + shared pepper across all minting services, SHA-256 fallback, use the `@pincerpay/db` helpers), new env vars (`TOKEN_PEPPER`, `SUPABASE_SMTP_CONFIGURED`, dashboard `TOKEN_PEPPER`), and the hashing module + cleanup script added to Key Files.

`llms.txt` needs no change — it's a link index pointing to the (now-updated) pages.

## Out of scope (tracked elsewhere)
The stale `AGENTS.md` merchant Express/Hono references are left to #142 (pre-existing slim-launch staleness, not this session's work) to keep this PR focused.

## Test plan
- [x] Docs/`.env.example` only — no code paths affected.
- [x] Verified the documented exports exist in `@pincerpay/db` and the env vars exist in config.

https://claude.ai/code/session_01KJhKgoX3z3UU5e8iknFTzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJhKgoX3z3UU5e8iknFTzX)_