### PR TITLE
docs: narrative SDK implementation guides (new "SDK Guides" section)

### DIFF
--- a/apps/dashboard/content/docs/guide-agent.md
+++ b/apps/dashboard/content/docs/guide-agent.md
@@ -1,0 +1,90 @@
+---
+title: "Agent SDK Functions"
+description: "Implementation guide to @pincerpay/agent — why create() exists, how fetch() handles 402s, and exactly what the spending policy does (and doesn't) enforce."
+order: 3.7
+section: SDK Guides
+---
+
+`@pincerpay/agent` gives an AI agent a wallet and a drop-in `fetch()` that pays for `402 Payment Required` resources automatically. The whole public surface is one class, `PincerPayAgent`, but a few of its methods have sharp edges worth understanding before you ship. This guide goes method by method.
+
+> **ESM-only**, single entry point. `import { PincerPayAgent } from "@pincerpay/agent"`. The type re-exports `AgentConfig`, `SpendingPolicy`, `AgentStatus`, and `AgentProfile` come from `@pincerpay/core`.
+
+## Construction: prefer `create()` over `new`
+
+There are two ways to instantiate, and the difference matters:
+
+```ts
+// Async factory — ALWAYS use this when a Solana key is involved.
+const agent = await PincerPayAgent.create({
+  chains: ["solana"],
+  solanaPrivateKey: process.env.AGENT_SOLANA_KEY!, // base58 keypair
+});
+
+// Synchronous constructor — EVM-only, registers the EVM scheme inline.
+const evmAgent = new PincerPayAgent({
+  chains: ["base"],
+  evmPrivateKey: process.env.AGENT_EVM_KEY!,        // 0x-prefixed hex
+});
+```
+
+The constructor is synchronous and **only registers the EVM payment scheme**. Solana key derivation is asynchronous (base58 decode → `createKeyPairSignerFromBytes`), so it only happens in the static `create()` factory. If you `new PincerPayAgent({ solanaPrivateKey })`, the Solana scheme is never wired up and `agent.solanaAddress` stays `undefined` — payments on Solana will silently not be signable. **Rule of thumb: always `await PincerPayAgent.create(...)`.** It works for EVM-only too, so you can standardize on it.
+
+Both forms require at least one key. With neither `evmPrivateKey` nor `solanaPrivateKey`, construction throws `"At least one wallet key (evmPrivateKey or solanaPrivateKey) is required"`. `AgentConfig` also takes `chains: string[]`, optional `policies: SpendingPolicy[]`, and an optional `facilitatorUrl` (defaults to production).
+
+## `fetch(url, init?)` — the whole point
+
+```ts
+const res = await agent.fetch("https://api.example.com/weather");
+const data = await res.json();
+```
+
+`fetch` mirrors the standard `fetch` signature (`string | URL`, optional `RequestInit`) and returns a normal `Response`. Under the hood it wraps the global fetch via `@x402/fetch`: when the server replies `402`, the SDK constructs and signs a USDC payment, submits it to the facilitator, and retries the original request — transparently. Your code only ever sees the final `200` (or a non-payment error). Spending-policy hooks fire during this flow; if a policy blocks the payment, the attempt aborts and the policy's `reason` surfaces.
+
+## Spending policies — read what they actually enforce
+
+This is the most important caveat in the package. A `SpendingPolicy` (from `@pincerpay/core`) has four fields — `maxPerTransaction`, `maxPerDay`, `allowedMerchants`, `allowedChains` — but the agent's runtime check **only enforces the two amount limits**:
+
+```ts
+const check = agent.checkPolicy("500000"); // 0.50 USDC, in BASE UNITS
+// → { allowed: boolean, reason?: string }
+```
+
+`checkPolicy` compares the base-unit amount against `maxPerTransaction` and the running daily total against `maxPerDay`. **`allowedMerchants` and `allowedChains` are part of the type and schema but are NOT enforced here** — do not rely on them as a security boundary in the SDK; gate those at your application layer. With no policies set, `checkPolicy` returns `{ allowed: true }`.
+
+Amounts are **base-unit strings** parsed to `BigInt`. Passing `"0.50"` will throw at runtime (`BigInt("0.50")` is invalid) — use `"500000"`.
+
+### Managing policy at runtime
+
+```ts
+agent.setPolicy({ maxPerTransaction: "1000000", maxPerDay: "10000000" }); // replaces ALL policies, resets daily tally
+agent.getPolicy();        // → the first SpendingPolicy | undefined
+agent.recordSpend("500000"); // add to today's tally
+agent.getDailySpend();    // → { date: "YYYY-MM-DD" (UTC), amount: bigint }
+```
+
+`setPolicy` **replaces** the entire policy list with the single policy you pass and clears daily tracking — it's not a merge. The daily window is keyed by the **UTC** calendar date and resets at midnight UTC. Spend tracking is **in-memory only**: it resets when the process restarts, so a long-lived daily cap needs your own persistence if the agent process is ephemeral.
+
+## Wallet inspection
+
+```ts
+agent.evmAddress;    // string | undefined  (derived from evmPrivateKey)
+agent.solanaAddress; // string | undefined  (only set when created via create())
+agent.chains;        // string[]            (echoes config.chains)
+```
+
+## A complete, safe setup
+
+```ts
+import { PincerPayAgent } from "@pincerpay/agent";
+
+const agent = await PincerPayAgent.create({
+  chains: ["solana", "base"],
+  solanaPrivateKey: process.env.AGENT_SOLANA_KEY!,
+  evmPrivateKey: process.env.AGENT_EVM_KEY!,
+  policies: [{ maxPerTransaction: "1000000", maxPerDay: "10000000" }], // base units
+});
+
+const res = await agent.fetch("https://api.example.com/paid-endpoint");
+```
+
+> **Never put agent keys in client-side code.** These keys spend real USDC — keep them server-side. See the [Agent SDK overview](/docs/agent-sdk) for the conceptual flow and the [Core guide](/docs/guide-core) for the base-units rule.

--- a/apps/dashboard/content/docs/guide-agent.md
+++ b/apps/dashboard/content/docs/guide-agent.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent SDK Functions"
-description: "Implementation guide to @pincerpay/agent — why create() exists, how fetch() handles 402s, and exactly what the spending policy does (and doesn't) enforce."
+description: "Implementation guide to @pincerpay/agent - why create() exists, how fetch() handles 402s, and exactly what the spending policy does (and doesn't) enforce."
 order: 3.7
 section: SDK Guides
 ---
@@ -14,44 +14,44 @@ section: SDK Guides
 There are two ways to instantiate, and the difference matters:
 
 ```ts
-// Async factory — ALWAYS use this when a Solana key is involved.
+// Async factory - ALWAYS use this when a Solana key is involved.
 const agent = await PincerPayAgent.create({
   chains: ["solana"],
   solanaPrivateKey: process.env.AGENT_SOLANA_KEY!, // base58 keypair
 });
 
-// Synchronous constructor — EVM-only, registers the EVM scheme inline.
+// Synchronous constructor - EVM-only, registers the EVM scheme inline.
 const evmAgent = new PincerPayAgent({
   chains: ["base"],
   evmPrivateKey: process.env.AGENT_EVM_KEY!,        // 0x-prefixed hex
 });
 ```
 
-The constructor is synchronous and **only registers the EVM payment scheme**. Solana key derivation is asynchronous (base58 decode → `createKeyPairSignerFromBytes`), so it only happens in the static `create()` factory. If you `new PincerPayAgent({ solanaPrivateKey })`, the Solana scheme is never wired up and `agent.solanaAddress` stays `undefined` — payments on Solana will silently not be signable. **Rule of thumb: always `await PincerPayAgent.create(...)`.** It works for EVM-only too, so you can standardize on it.
+The constructor is synchronous and **only registers the EVM payment scheme**. Solana key derivation is asynchronous (base58 decode → `createKeyPairSignerFromBytes`), so it only happens in the static `create()` factory. If you `new PincerPayAgent({ solanaPrivateKey })`, the Solana scheme is never wired up and `agent.solanaAddress` stays `undefined` - payments on Solana will silently not be signable. **Rule of thumb: always `await PincerPayAgent.create(...)`.** It works for EVM-only too, so you can standardize on it.
 
 Both forms require at least one key. With neither `evmPrivateKey` nor `solanaPrivateKey`, construction throws `"At least one wallet key (evmPrivateKey or solanaPrivateKey) is required"`. `AgentConfig` also takes `chains: string[]`, optional `policies: SpendingPolicy[]`, and an optional `facilitatorUrl` (defaults to production).
 
-## `fetch(url, init?)` — the whole point
+## `fetch(url, init?)` - the whole point
 
 ```ts
 const res = await agent.fetch("https://api.example.com/weather");
 const data = await res.json();
 ```
 
-`fetch` mirrors the standard `fetch` signature (`string | URL`, optional `RequestInit`) and returns a normal `Response`. Under the hood it wraps the global fetch via `@x402/fetch`: when the server replies `402`, the SDK constructs and signs a USDC payment, submits it to the facilitator, and retries the original request — transparently. Your code only ever sees the final `200` (or a non-payment error). Spending-policy hooks fire during this flow; if a policy blocks the payment, the attempt aborts and the policy's `reason` surfaces.
+`fetch` mirrors the standard `fetch` signature (`string | URL`, optional `RequestInit`) and returns a normal `Response`. Under the hood it wraps the global fetch via `@x402/fetch`: when the server replies `402`, the SDK constructs and signs a USDC payment, submits it to the facilitator, and retries the original request - transparently. Your code only ever sees the final `200` (or a non-payment error). Spending-policy hooks fire during this flow; if a policy blocks the payment, the attempt aborts and the policy's `reason` surfaces.
 
-## Spending policies — read what they actually enforce
+## Spending policies - read what they actually enforce
 
-This is the most important caveat in the package. A `SpendingPolicy` (from `@pincerpay/core`) has four fields — `maxPerTransaction`, `maxPerDay`, `allowedMerchants`, `allowedChains` — but the agent's runtime check **only enforces the two amount limits**:
+This is the most important caveat in the package. A `SpendingPolicy` (from `@pincerpay/core`) has four fields - `maxPerTransaction`, `maxPerDay`, `allowedMerchants`, `allowedChains` - but the agent's runtime check **only enforces the two amount limits**:
 
 ```ts
 const check = agent.checkPolicy("500000"); // 0.50 USDC, in BASE UNITS
 // → { allowed: boolean, reason?: string }
 ```
 
-`checkPolicy` compares the base-unit amount against `maxPerTransaction` and the running daily total against `maxPerDay`. **`allowedMerchants` and `allowedChains` are part of the type and schema but are NOT enforced here** — do not rely on them as a security boundary in the SDK; gate those at your application layer. With no policies set, `checkPolicy` returns `{ allowed: true }`.
+`checkPolicy` compares the base-unit amount against `maxPerTransaction` and the running daily total against `maxPerDay`. **`allowedMerchants` and `allowedChains` are part of the type and schema but are NOT enforced here** - do not rely on them as a security boundary in the SDK; gate those at your application layer. With no policies set, `checkPolicy` returns `{ allowed: true }`.
 
-Amounts are **base-unit strings** parsed to `BigInt`. Passing `"0.50"` will throw at runtime (`BigInt("0.50")` is invalid) — use `"500000"`.
+Amounts are **base-unit strings** parsed to `BigInt`. Passing `"0.50"` will throw at runtime (`BigInt("0.50")` is invalid) - use `"500000"`.
 
 ### Managing policy at runtime
 
@@ -62,7 +62,7 @@ agent.recordSpend("500000"); // add to today's tally
 agent.getDailySpend();    // → { date: "YYYY-MM-DD" (UTC), amount: bigint }
 ```
 
-`setPolicy` **replaces** the entire policy list with the single policy you pass and clears daily tracking — it's not a merge. The daily window is keyed by the **UTC** calendar date and resets at midnight UTC. Spend tracking is **in-memory only**: it resets when the process restarts, so a long-lived daily cap needs your own persistence if the agent process is ephemeral.
+`setPolicy` **replaces** the entire policy list with the single policy you pass and clears daily tracking - it's not a merge. The daily window is keyed by the **UTC** calendar date and resets at midnight UTC. Spend tracking is **in-memory only**: it resets when the process restarts, so a long-lived daily cap needs your own persistence if the agent process is ephemeral.
 
 ## Wallet inspection
 
@@ -87,4 +87,4 @@ const agent = await PincerPayAgent.create({
 const res = await agent.fetch("https://api.example.com/paid-endpoint");
 ```
 
-> **Never put agent keys in client-side code.** These keys spend real USDC — keep them server-side. See the [Agent SDK overview](/docs/agent-sdk) for the conceptual flow and the [Core guide](/docs/guide-core) for the base-units rule.
+> **Never put agent keys in client-side code.** These keys spend real USDC - keep them server-side. See the [Agent SDK overview](/docs/agent-sdk) for the conceptual flow and the [Core guide](/docs/guide-core) for the base-units rule.

--- a/apps/dashboard/content/docs/guide-agent.md
+++ b/apps/dashboard/content/docs/guide-agent.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent SDK Functions"
-description: "Implementation guide to @pincerpay/agent - why create() exists, how fetch() handles 402s, and exactly what the spending policy does (and doesn't) enforce."
+description: "Implementation guide to @pincerpay/agent: why create() exists, how fetch() handles 402s, and exactly what the spending policy does (and doesn't) enforce."
 order: 3.7
 section: SDK Guides
 ---
@@ -14,44 +14,44 @@ section: SDK Guides
 There are two ways to instantiate, and the difference matters:
 
 ```ts
-// Async factory - ALWAYS use this when a Solana key is involved.
+// Async factory: ALWAYS use this when a Solana key is involved.
 const agent = await PincerPayAgent.create({
   chains: ["solana"],
   solanaPrivateKey: process.env.AGENT_SOLANA_KEY!, // base58 keypair
 });
 
-// Synchronous constructor - EVM-only, registers the EVM scheme inline.
+// Synchronous constructor: EVM-only, registers the EVM scheme inline.
 const evmAgent = new PincerPayAgent({
   chains: ["base"],
   evmPrivateKey: process.env.AGENT_EVM_KEY!,        // 0x-prefixed hex
 });
 ```
 
-The constructor is synchronous and **only registers the EVM payment scheme**. Solana key derivation is asynchronous (base58 decode → `createKeyPairSignerFromBytes`), so it only happens in the static `create()` factory. If you `new PincerPayAgent({ solanaPrivateKey })`, the Solana scheme is never wired up and `agent.solanaAddress` stays `undefined` - payments on Solana will silently not be signable. **Rule of thumb: always `await PincerPayAgent.create(...)`.** It works for EVM-only too, so you can standardize on it.
+The constructor is synchronous and **only registers the EVM payment scheme**. Solana key derivation is asynchronous (base58 decode, then `createKeyPairSignerFromBytes`), so it only happens in the static `create()` factory. If you call `new PincerPayAgent({ solanaPrivateKey })`, the Solana scheme is never wired up and `agent.solanaAddress` stays `undefined`, so payments on Solana will silently fail to sign. The rule of thumb is simple: always `await PincerPayAgent.create(...)`. It works for EVM-only too, so you can standardize on it.
 
 Both forms require at least one key. With neither `evmPrivateKey` nor `solanaPrivateKey`, construction throws `"At least one wallet key (evmPrivateKey or solanaPrivateKey) is required"`. `AgentConfig` also takes `chains: string[]`, optional `policies: SpendingPolicy[]`, and an optional `facilitatorUrl` (defaults to production).
 
-## `fetch(url, init?)` - the whole point
+## `fetch(url, init?)`: the whole point
 
 ```ts
 const res = await agent.fetch("https://api.example.com/weather");
 const data = await res.json();
 ```
 
-`fetch` mirrors the standard `fetch` signature (`string | URL`, optional `RequestInit`) and returns a normal `Response`. Under the hood it wraps the global fetch via `@x402/fetch`: when the server replies `402`, the SDK constructs and signs a USDC payment, submits it to the facilitator, and retries the original request - transparently. Your code only ever sees the final `200` (or a non-payment error). Spending-policy hooks fire during this flow; if a policy blocks the payment, the attempt aborts and the policy's `reason` surfaces.
+`fetch` mirrors the standard `fetch` signature (`string | URL`, optional `RequestInit`) and returns a normal `Response`. Under the hood it wraps the global fetch via `@x402/fetch`: when the server replies `402`, the SDK constructs and signs a USDC payment, submits it to the facilitator, and retries the original request, all transparently. Your code only ever sees the final `200` (or a non-payment error). Spending-policy hooks fire during this flow, and if a policy blocks the payment the attempt aborts and the policy's `reason` surfaces.
 
-## Spending policies - read what they actually enforce
+## Spending policies: what they actually enforce
 
-This is the most important caveat in the package. A `SpendingPolicy` (from `@pincerpay/core`) has four fields - `maxPerTransaction`, `maxPerDay`, `allowedMerchants`, `allowedChains` - but the agent's runtime check **only enforces the two amount limits**:
+This is the most important caveat in the package. A `SpendingPolicy` (from `@pincerpay/core`) has four fields (`maxPerTransaction`, `maxPerDay`, `allowedMerchants`, `allowedChains`), but the agent's runtime check **only enforces the two amount limits**:
 
 ```ts
 const check = agent.checkPolicy("500000"); // 0.50 USDC, in BASE UNITS
 // → { allowed: boolean, reason?: string }
 ```
 
-`checkPolicy` compares the base-unit amount against `maxPerTransaction` and the running daily total against `maxPerDay`. **`allowedMerchants` and `allowedChains` are part of the type and schema but are NOT enforced here** - do not rely on them as a security boundary in the SDK; gate those at your application layer. With no policies set, `checkPolicy` returns `{ allowed: true }`.
+`checkPolicy` compares the base-unit amount against `maxPerTransaction` and the running daily total against `maxPerDay`. **`allowedMerchants` and `allowedChains` are part of the type and schema but are NOT enforced here**, so do not rely on them as a security boundary in the SDK; gate those at your application layer. With no policies set, `checkPolicy` returns `{ allowed: true }`.
 
-Amounts are **base-unit strings** parsed to `BigInt`. Passing `"0.50"` will throw at runtime (`BigInt("0.50")` is invalid) - use `"500000"`.
+Amounts are **base-unit strings** parsed to `BigInt`. Passing `"0.50"` will throw at runtime because `BigInt("0.50")` is invalid, so use `"500000"`.
 
 ### Managing policy at runtime
 
@@ -62,7 +62,7 @@ agent.recordSpend("500000"); // add to today's tally
 agent.getDailySpend();    // → { date: "YYYY-MM-DD" (UTC), amount: bigint }
 ```
 
-`setPolicy` **replaces** the entire policy list with the single policy you pass and clears daily tracking - it's not a merge. The daily window is keyed by the **UTC** calendar date and resets at midnight UTC. Spend tracking is **in-memory only**: it resets when the process restarts, so a long-lived daily cap needs your own persistence if the agent process is ephemeral.
+`setPolicy` **replaces** the entire policy list with the single policy you pass and clears daily tracking; it is not a merge. The daily window is keyed by the **UTC** calendar date and resets at midnight UTC. Spend tracking is **in-memory only**, so it resets when the process restarts, and a long-lived daily cap needs your own persistence if the agent process is ephemeral.
 
 ## Wallet inspection
 
@@ -87,4 +87,4 @@ const agent = await PincerPayAgent.create({
 const res = await agent.fetch("https://api.example.com/paid-endpoint");
 ```
 
-> **Never put agent keys in client-side code.** These keys spend real USDC - keep them server-side. See the [Agent SDK overview](/docs/agent-sdk) for the conceptual flow and the [Core guide](/docs/guide-core) for the base-units rule.
+> **Never put agent keys in client-side code.** These keys spend real USDC, so keep them server-side. See the [Agent SDK overview](/docs/agent-sdk) for the conceptual flow and the [Core guide](/docs/guide-core) for the base-units rule.

--- a/apps/dashboard/content/docs/guide-core.md
+++ b/apps/dashboard/content/docs/guide-core.md
@@ -1,0 +1,92 @@
+---
+title: "Core: Chains, Addresses & Config"
+description: "A function-by-function guide to @pincerpay/core — chain resolution, address validation, config schemas, and the base-units rule that trips everyone up."
+order: 3.6
+section: SDK Guides
+---
+
+`@pincerpay/core` is the shared foundation every other PincerPay package builds on. You rarely install it alone, but understanding its functions explains how chains are named, how addresses are validated, and — most importantly — the one unit convention that causes the majority of integration bugs. This guide walks each public function in the order you'll actually meet them.
+
+> **ESM-only.** Like every PincerPay package, `@pincerpay/core` ships ESM only. Your project needs `"type": "module"` and `.js` import specifiers.
+
+## The base-units rule (read this first)
+
+USDC has **6 decimals**. Two different conventions coexist in the API, and mixing them up is the #1 source of "why did my agent pay 1,000,000 USDC" bugs:
+
+- **Base units** — integer strings where `"1000000"` = 1 USDC. Used by `Transaction.amount`, `SpendingPolicy.maxPerTransaction`/`maxPerDay`, and the agent's `checkPolicy`/`recordSpend`.
+- **Human decimals** — strings like `"0.01"`. Used only by paywall `price` fields (`RoutePaywallConfig`).
+
+`USDC_DECIMALS` (6) and `OPTIMISTIC_THRESHOLD` (`"1000000"`, the sub-1-USDC fast-release cutoff) are exported constants. When in doubt, you're probably in base units — only route pricing is human-readable, and `@pincerpay/merchant`'s `toBaseUnits` converts that for you.
+
+## Resolving chains
+
+PincerPay identifies chains two ways: short names (`solana`, `base`, `polygon`, `solana-devnet`, `base-sepolia`, `polygon-amoy`) and [CAIP-2](/docs/chain-architecture) IDs. Two functions bridge them, and they fail differently on purpose:
+
+```ts
+import { resolveChain, toCAIP2 } from "@pincerpay/core";
+
+resolveChain("solana");        // → ChainConfig | undefined  (never throws)
+resolveChain("eip155:8453");   // → ChainConfig (accepts CAIP-2 too)
+resolveChain("dogecoin");      // → undefined
+
+toCAIP2("base");               // → "eip155:8453"
+toCAIP2("dogecoin");           // throws: Unknown chain: "dogecoin". Valid chains: ...
+```
+
+Use `resolveChain` when an unknown chain is an expected, recoverable case (you'll branch on `undefined`). Use `toCAIP2` at trust boundaries where an unknown chain is a programming error you want surfaced loudly. `getMainnetChains()` and `getTestnetChains()` return the `ChainConfig[]` for each environment — handy for building selectors or validating that a test key isn't pointed at mainnet.
+
+Each `ChainConfig` carries the chain's CAIP-2 ID, namespace, and USDC contract address, so you rarely hard-code an address yourself.
+
+## Validating addresses
+
+These are **format** checks, not on-chain existence or checksum checks — cheap guards for user input before you hand an address to the facilitator:
+
+```ts
+import { isValidSolanaAddress, isValidEvmAddress } from "@pincerpay/core";
+
+isValidSolanaAddress("11111111111111111111111111111111"); // base58, 32–44 chars
+isValidEvmAddress("0xab...40hex");                          // 0x + 40 hex, case-insensitive
+```
+
+`isValidEvmAddress` does **not** enforce EIP-55 checksum casing, and `isValidSolanaAddress` does **not** verify the key is on-curve or a real mint — treat them as "looks plausible," not "is valid and exists."
+
+For the chain-aware version, use `getChainNamespace(shorthand)` (returns `"eip155"` or `"solana"`, **throws** on unknown chain) and `validateMerchantAddressForChain(address, shorthand)`, which returns `null` on success or a **human-readable error string** on failure:
+
+```ts
+const err = validateMerchantAddressForChain(addr, "polygon");
+if (err) return res.status(400).json({ error: err }); // err is already a sentence
+```
+
+## Picking the right merchant address
+
+Merchants can configure a single `merchantAddress` or a per-chain `merchantAddresses` map. `resolveMerchantAddress` encodes the precedence so every package resolves identically:
+
+```ts
+resolveMerchantAddress({ merchantAddress, merchantAddresses }, "solana");
+// 1. merchantAddresses["solana"]  (case-insensitive key match)
+// 2. merchantAddress              (legacy single fallback)
+// 3. undefined
+```
+
+This is the exact logic the merchant middleware runs at startup, so calling it yourself is a good pre-flight check that every chain you intend to serve actually has a wallet.
+
+## Config schemas (Zod)
+
+`@pincerpay/core` exports the Zod schemas the SDKs validate against. They live alongside the types and are worth using directly if you build your own config layer:
+
+- `PincerPayConfigSchema` — validates a merchant config. Its `.refine()` requires **either** `merchantAddress` **or** a non-empty `merchantAddresses` (error reported on the `merchantAddresses` path), and `facilitatorUrl` must be a valid URL when present.
+- `RoutePaywallConfigSchema` — `price` must match `^\d+\.?\d*$` (a human USDC decimal string like `"0.01"`); `chain`, `chains`, and `description` are optional.
+- `SpendingPolicySchema` — all fields optional; the limit fields are base-unit strings.
+
+```ts
+import { PincerPayConfigSchema } from "@pincerpay/core";
+const config = PincerPayConfigSchema.parse(rawConfig); // throws ZodError with a path you can surface
+```
+
+## Constants worth knowing
+
+`DEFAULT_FACILITATOR_URL` (`https://facilitator.pincerpay.com`), `API_KEY_HEADER` (`x-pincerpay-api-key`), `API_KEY_LIVE_PREFIX`/`API_KEY_TEST_PREFIX` (`pp_live_`/`pp_test_`), `API_KEY_PREFIX_LENGTH` (12), and `FACILITATOR_ROUTES` (the canonical path map) mean you never have to string-build a facilitator URL or guess a header name.
+
+## Where next
+
+These primitives power the [Merchant SDK guide](/docs/guide-merchant) (which calls `resolveChain`, `resolveMerchantAddress`, and `validateMerchantAddressForChain` at startup) and the [Agent SDK guide](/docs/guide-agent) (which consumes `SpendingPolicy` and base-unit amounts).

--- a/apps/dashboard/content/docs/guide-core.md
+++ b/apps/dashboard/content/docs/guide-core.md
@@ -1,11 +1,11 @@
 ---
 title: "Core: Chains, Addresses & Config"
-description: "A function-by-function guide to @pincerpay/core - chain resolution, address validation, config schemas, and the base-units rule that trips everyone up."
+description: "A function-by-function guide to @pincerpay/core: chain resolution, address validation, config schemas, and the base-units rule that trips everyone up."
 order: 3.6
 section: SDK Guides
 ---
 
-`@pincerpay/core` is the shared foundation every other PincerPay package builds on. You rarely install it alone, but understanding its functions explains how chains are named, how addresses are validated, and - most importantly - the one unit convention that causes the majority of integration bugs. This guide walks each public function in the order you'll actually meet them.
+`@pincerpay/core` is the shared foundation every other PincerPay package builds on. You rarely install it alone, but understanding its functions explains how chains are named, how addresses are validated, and (most importantly) the one unit convention that causes the majority of integration bugs. This guide walks each public function in the order you'll actually meet them.
 
 > **ESM-only.** Like every PincerPay package, `@pincerpay/core` ships ESM only. Your project needs `"type": "module"` and `.js` import specifiers.
 
@@ -13,10 +13,10 @@ section: SDK Guides
 
 USDC has **6 decimals**. Two different conventions coexist in the API, and mixing them up is the #1 source of "why did my agent pay 1,000,000 USDC" bugs:
 
-- **Base units** - integer strings where `"1000000"` = 1 USDC. Used by `Transaction.amount`, `SpendingPolicy.maxPerTransaction`/`maxPerDay`, and the agent's `checkPolicy`/`recordSpend`.
-- **Human decimals** - strings like `"0.01"`. Used only by paywall `price` fields (`RoutePaywallConfig`).
+- **Base units** are integer strings where `"1000000"` equals 1 USDC. They're used by `Transaction.amount`, `SpendingPolicy.maxPerTransaction`/`maxPerDay`, and the agent's `checkPolicy`/`recordSpend`.
+- **Human decimals** are strings like `"0.01"`. They're used only by paywall `price` fields (`RoutePaywallConfig`).
 
-`USDC_DECIMALS` (6) and `OPTIMISTIC_THRESHOLD` (`"1000000"`, the sub-1-USDC fast-release cutoff) are exported constants. When in doubt, you're probably in base units - only route pricing is human-readable, and `@pincerpay/merchant`'s `toBaseUnits` converts that for you.
+`USDC_DECIMALS` (6) and `OPTIMISTIC_THRESHOLD` (`"1000000"`, the sub-1-USDC fast-release cutoff) are exported constants. When in doubt, you're probably in base units: only route pricing is human-readable, and `@pincerpay/merchant`'s `toBaseUnits` converts that for you.
 
 ## Resolving chains
 
@@ -33,13 +33,13 @@ toCAIP2("base");               // → "eip155:8453"
 toCAIP2("dogecoin");           // throws: Unknown chain: "dogecoin". Valid chains: ...
 ```
 
-Use `resolveChain` when an unknown chain is an expected, recoverable case (you'll branch on `undefined`). Use `toCAIP2` at trust boundaries where an unknown chain is a programming error you want surfaced loudly. `getMainnetChains()` and `getTestnetChains()` return the `ChainConfig[]` for each environment - handy for building selectors or validating that a test key isn't pointed at mainnet.
+Use `resolveChain` when an unknown chain is an expected, recoverable case that you'll branch on via `undefined`. Reach for `toCAIP2` at trust boundaries where an unknown chain is a programming error you want surfaced loudly. `getMainnetChains()` and `getTestnetChains()` return the `ChainConfig[]` for each environment, which is handy for building selectors or for confirming a test key isn't pointed at mainnet.
 
 Each `ChainConfig` carries the chain's CAIP-2 ID, namespace, and USDC contract address, so you rarely hard-code an address yourself.
 
 ## Validating addresses
 
-These are **format** checks, not on-chain existence or checksum checks - cheap guards for user input before you hand an address to the facilitator:
+These are **format** checks rather than on-chain existence or checksum checks. Treat them as cheap guards for user input before you hand an address to the facilitator:
 
 ```ts
 import { isValidSolanaAddress, isValidEvmAddress } from "@pincerpay/core";
@@ -48,9 +48,9 @@ isValidSolanaAddress("11111111111111111111111111111111"); // base58, 32–44 cha
 isValidEvmAddress("0xab...40hex");                          // 0x + 40 hex, case-insensitive
 ```
 
-`isValidEvmAddress` does **not** enforce EIP-55 checksum casing, and `isValidSolanaAddress` does **not** verify the key is on-curve or a real mint - treat them as "looks plausible," not "is valid and exists."
+`isValidEvmAddress` does **not** enforce EIP-55 checksum casing, and `isValidSolanaAddress` does **not** verify the key is on-curve or a real mint, so treat them as "looks plausible," not "is valid and exists."
 
-For the chain-aware version, use `getChainNamespace(shorthand)` (returns `"eip155"` or `"solana"`, **throws** on unknown chain) and `validateMerchantAddressForChain(address, shorthand)`, which returns `null` on success or a **human-readable error string** on failure:
+For the chain-aware version, use `getChainNamespace(shorthand)` (it returns `"eip155"` or `"solana"`, and **throws** on an unknown chain) and `validateMerchantAddressForChain(address, shorthand)`, which returns `null` on success or a **human-readable error string** on failure:
 
 ```ts
 const err = validateMerchantAddressForChain(addr, "polygon");
@@ -74,9 +74,9 @@ This is the exact logic the merchant middleware runs at startup, so calling it y
 
 `@pincerpay/core` exports the Zod schemas the SDKs validate against. They live alongside the types and are worth using directly if you build your own config layer:
 
-- `PincerPayConfigSchema` - validates a merchant config. Its `.refine()` requires **either** `merchantAddress` **or** a non-empty `merchantAddresses` (error reported on the `merchantAddresses` path), and `facilitatorUrl` must be a valid URL when present.
-- `RoutePaywallConfigSchema` - `price` must match `^\d+\.?\d*$` (a human USDC decimal string like `"0.01"`); `chain`, `chains`, and `description` are optional.
-- `SpendingPolicySchema` - all fields optional; the limit fields are base-unit strings.
+- `PincerPayConfigSchema` validates a merchant config. Its `.refine()` requires **either** `merchantAddress` **or** a non-empty `merchantAddresses` (the error is reported on the `merchantAddresses` path), and `facilitatorUrl` must be a valid URL when present.
+- `RoutePaywallConfigSchema` requires `price` to match `^\d+\.?\d*$` (a human USDC decimal string like `"0.01"`); `chain`, `chains`, and `description` are optional.
+- `SpendingPolicySchema` makes all fields optional, and the limit fields are base-unit strings.
 
 ```ts
 import { PincerPayConfigSchema } from "@pincerpay/core";
@@ -89,4 +89,4 @@ const config = PincerPayConfigSchema.parse(rawConfig); // throws ZodError with a
 
 ## Where next
 
-These primitives power the [Merchant SDK guide](/docs/guide-merchant) (which calls `resolveChain`, `resolveMerchantAddress`, and `validateMerchantAddressForChain` at startup) and the [Agent SDK guide](/docs/guide-agent) (which consumes `SpendingPolicy` and base-unit amounts).
+These primitives power the [Merchant SDK guide](/docs/guide-merchant), which calls `resolveChain`, `resolveMerchantAddress`, and `validateMerchantAddressForChain` at startup, and the [Agent SDK guide](/docs/guide-agent), which consumes `SpendingPolicy` and base-unit amounts.

--- a/apps/dashboard/content/docs/guide-core.md
+++ b/apps/dashboard/content/docs/guide-core.md
@@ -1,11 +1,11 @@
 ---
 title: "Core: Chains, Addresses & Config"
-description: "A function-by-function guide to @pincerpay/core — chain resolution, address validation, config schemas, and the base-units rule that trips everyone up."
+description: "A function-by-function guide to @pincerpay/core - chain resolution, address validation, config schemas, and the base-units rule that trips everyone up."
 order: 3.6
 section: SDK Guides
 ---
 
-`@pincerpay/core` is the shared foundation every other PincerPay package builds on. You rarely install it alone, but understanding its functions explains how chains are named, how addresses are validated, and — most importantly — the one unit convention that causes the majority of integration bugs. This guide walks each public function in the order you'll actually meet them.
+`@pincerpay/core` is the shared foundation every other PincerPay package builds on. You rarely install it alone, but understanding its functions explains how chains are named, how addresses are validated, and - most importantly - the one unit convention that causes the majority of integration bugs. This guide walks each public function in the order you'll actually meet them.
 
 > **ESM-only.** Like every PincerPay package, `@pincerpay/core` ships ESM only. Your project needs `"type": "module"` and `.js` import specifiers.
 
@@ -13,10 +13,10 @@ section: SDK Guides
 
 USDC has **6 decimals**. Two different conventions coexist in the API, and mixing them up is the #1 source of "why did my agent pay 1,000,000 USDC" bugs:
 
-- **Base units** — integer strings where `"1000000"` = 1 USDC. Used by `Transaction.amount`, `SpendingPolicy.maxPerTransaction`/`maxPerDay`, and the agent's `checkPolicy`/`recordSpend`.
-- **Human decimals** — strings like `"0.01"`. Used only by paywall `price` fields (`RoutePaywallConfig`).
+- **Base units** - integer strings where `"1000000"` = 1 USDC. Used by `Transaction.amount`, `SpendingPolicy.maxPerTransaction`/`maxPerDay`, and the agent's `checkPolicy`/`recordSpend`.
+- **Human decimals** - strings like `"0.01"`. Used only by paywall `price` fields (`RoutePaywallConfig`).
 
-`USDC_DECIMALS` (6) and `OPTIMISTIC_THRESHOLD` (`"1000000"`, the sub-1-USDC fast-release cutoff) are exported constants. When in doubt, you're probably in base units — only route pricing is human-readable, and `@pincerpay/merchant`'s `toBaseUnits` converts that for you.
+`USDC_DECIMALS` (6) and `OPTIMISTIC_THRESHOLD` (`"1000000"`, the sub-1-USDC fast-release cutoff) are exported constants. When in doubt, you're probably in base units - only route pricing is human-readable, and `@pincerpay/merchant`'s `toBaseUnits` converts that for you.
 
 ## Resolving chains
 
@@ -33,13 +33,13 @@ toCAIP2("base");               // → "eip155:8453"
 toCAIP2("dogecoin");           // throws: Unknown chain: "dogecoin". Valid chains: ...
 ```
 
-Use `resolveChain` when an unknown chain is an expected, recoverable case (you'll branch on `undefined`). Use `toCAIP2` at trust boundaries where an unknown chain is a programming error you want surfaced loudly. `getMainnetChains()` and `getTestnetChains()` return the `ChainConfig[]` for each environment — handy for building selectors or validating that a test key isn't pointed at mainnet.
+Use `resolveChain` when an unknown chain is an expected, recoverable case (you'll branch on `undefined`). Use `toCAIP2` at trust boundaries where an unknown chain is a programming error you want surfaced loudly. `getMainnetChains()` and `getTestnetChains()` return the `ChainConfig[]` for each environment - handy for building selectors or validating that a test key isn't pointed at mainnet.
 
 Each `ChainConfig` carries the chain's CAIP-2 ID, namespace, and USDC contract address, so you rarely hard-code an address yourself.
 
 ## Validating addresses
 
-These are **format** checks, not on-chain existence or checksum checks — cheap guards for user input before you hand an address to the facilitator:
+These are **format** checks, not on-chain existence or checksum checks - cheap guards for user input before you hand an address to the facilitator:
 
 ```ts
 import { isValidSolanaAddress, isValidEvmAddress } from "@pincerpay/core";
@@ -48,7 +48,7 @@ isValidSolanaAddress("11111111111111111111111111111111"); // base58, 32–44 cha
 isValidEvmAddress("0xab...40hex");                          // 0x + 40 hex, case-insensitive
 ```
 
-`isValidEvmAddress` does **not** enforce EIP-55 checksum casing, and `isValidSolanaAddress` does **not** verify the key is on-curve or a real mint — treat them as "looks plausible," not "is valid and exists."
+`isValidEvmAddress` does **not** enforce EIP-55 checksum casing, and `isValidSolanaAddress` does **not** verify the key is on-curve or a real mint - treat them as "looks plausible," not "is valid and exists."
 
 For the chain-aware version, use `getChainNamespace(shorthand)` (returns `"eip155"` or `"solana"`, **throws** on unknown chain) and `validateMerchantAddressForChain(address, shorthand)`, which returns `null` on success or a **human-readable error string** on failure:
 
@@ -74,9 +74,9 @@ This is the exact logic the merchant middleware runs at startup, so calling it y
 
 `@pincerpay/core` exports the Zod schemas the SDKs validate against. They live alongside the types and are worth using directly if you build your own config layer:
 
-- `PincerPayConfigSchema` — validates a merchant config. Its `.refine()` requires **either** `merchantAddress` **or** a non-empty `merchantAddresses` (error reported on the `merchantAddresses` path), and `facilitatorUrl` must be a valid URL when present.
-- `RoutePaywallConfigSchema` — `price` must match `^\d+\.?\d*$` (a human USDC decimal string like `"0.01"`); `chain`, `chains`, and `description` are optional.
-- `SpendingPolicySchema` — all fields optional; the limit fields are base-unit strings.
+- `PincerPayConfigSchema` - validates a merchant config. Its `.refine()` requires **either** `merchantAddress` **or** a non-empty `merchantAddresses` (error reported on the `merchantAddresses` path), and `facilitatorUrl` must be a valid URL when present.
+- `RoutePaywallConfigSchema` - `price` must match `^\d+\.?\d*$` (a human USDC decimal string like `"0.01"`); `chain`, `chains`, and `description` are optional.
+- `SpendingPolicySchema` - all fields optional; the limit fields are base-unit strings.
 
 ```ts
 import { PincerPayConfigSchema } from "@pincerpay/core";

--- a/apps/dashboard/content/docs/guide-db.md
+++ b/apps/dashboard/content/docs/guide-db.md
@@ -1,15 +1,15 @@
 ---
 title: "Database & Key Hashing Functions"
-description: "Implementation guide to @pincerpay/db - the connection factory, the API-key hashing helpers, and the TOKEN_PEPPER rule that keeps keys verifiable across services."
+description: "Implementation guide to @pincerpay/db: the connection factory, the API-key hashing helpers, and the TOKEN_PEPPER rule that keeps keys verifiable across services."
 order: 3.95
 section: SDK Guides
 ---
 
-`@pincerpay/db` is the Drizzle ORM schema and Postgres client behind PincerPay. Most teams consume it indirectly (via the facilitator, dashboard, or `@pincerpay/onboarding`), but its connection factory and - new in 0.3.0 - its API-key hashing helpers are the canonical building blocks for anything that touches merchants, keys, or transactions directly. This guide covers each, plus the cross-service `TOKEN_PEPPER` contract.
+`@pincerpay/db` is the Drizzle ORM schema and Postgres client behind PincerPay. Most teams consume it indirectly (via the facilitator, dashboard, or `@pincerpay/onboarding`), but its connection factory and its API-key hashing helpers (new in 0.3.0) are the canonical building blocks for anything that touches merchants, keys, or transactions directly. This guide covers each, plus the cross-service `TOKEN_PEPPER` contract.
 
-> **ESM-only, server-side.** It uses the Node `postgres` driver and `node:crypto`; it never belongs in a browser bundle. Two entry points: `@pincerpay/db` (client + hashing + schema) and `@pincerpay/db/schema` (schema only).
+> **ESM-only, server-side.** It uses the Node `postgres` driver and `node:crypto`, so it never belongs in a browser bundle. Two entry points: `@pincerpay/db` (client + hashing + schema) and `@pincerpay/db/schema` (schema only).
 
-## `createDb(connectionString, options?)` - the connection factory
+## `createDb(connectionString, options?)`: the connection factory
 
 ```ts
 import { createDb, transactions } from "@pincerpay/db";
@@ -20,22 +20,22 @@ try {
   const rows = await db.select().from(transactions)
     .where(eq(transactions.merchantId, id)).limit(10);
 } finally {
-  await close(); // ALWAYS close - especially in serverless
+  await close(); // ALWAYS close, especially in serverless
 }
 ```
 
-Returns `{ db, close }` where `db` is a Drizzle instance bound to the full schema and `close()` ends the underlying pool. The `Database` type is exported for typing functions that accept the client (`db: Database`).
+It returns `{ db, close }`, where `db` is a Drizzle instance bound to the full schema and `close()` ends the underlying pool. The `Database` type is exported for typing functions that accept the client (`db: Database`).
 
 It adapts to your connection automatically:
 
 - `{ serverless: true }` caps the pool at `max: 1` (right for Vercel/Lambda); the default is `max: 10`.
-- **Pooler detection:** if the connection string contains `:6543` (Supabase's transaction pooler) it disables prepared statements (`prepare: false`) and requires TLS (`ssl: "require"`). A direct `:5432` connection uses `prepare: true`, `ssl: false`. So point serverless code at the `:6543` pooler URL and long-lived services at `:5432` - `createDb` does the rest.
+- **Pooler detection:** if the connection string contains `:6543` (Supabase's transaction pooler), it disables prepared statements (`prepare: false`) and requires TLS (`ssl: "require"`). A direct `:5432` connection uses `prepare: true`, `ssl: false`. So point serverless code at the `:6543` pooler URL and long-lived services at `:5432`, and `createDb` does the rest.
 
-The one rule: **call `close()`** when you're done (or on shutdown). Leaked pools are the classic serverless failure.
+There's one rule to remember: **call `close()`** when you're done (or on shutdown). Leaked pools are the classic serverless failure.
 
 ## API-key hashing helpers
 
-API keys are never stored in plaintext. As of migration `0004`, PincerPay hashes them with **HMAC-SHA256 + a server pepper** (matching `cli_sessions`), with a legacy SHA-256 path for backward compatibility. Use these helpers at every mint and verify site so the scheme stays consistent - don't re-implement hashing inline.
+API keys are never stored in plaintext. As of migration `0004`, PincerPay hashes them with **HMAC-SHA256 + a server pepper** (matching `cli_sessions`), with a legacy SHA-256 path for backward compatibility. Use these helpers at every mint and verify site so the scheme stays consistent, and don't re-implement hashing inline.
 
 ### Minting
 
@@ -46,7 +46,7 @@ const { keyHash, keyHashHmac } = hashNewApiKey(rawKey); // reads TOKEN_PEPPER fr
 await db.insert(apiKeys).values({ merchantId, keyHash, keyHashHmac, prefix, label, environment });
 ```
 
-`hashNewApiKey(rawKey, env?)` returns a `MintedApiKeyHash` with **exactly one** column populated: if a pepper is available it returns `{ keyHashHmac: <hmac>, keyHash: null }`; otherwise it falls back to `{ keyHashHmac: null, keyHash: <sha256> }`. The fallback means key creation never hard-fails just because a pepper isn't configured - but a fallback key is a legacy SHA-256 key.
+`hashNewApiKey(rawKey, env?)` returns a `MintedApiKeyHash` with **exactly one** column populated: if a pepper is available it returns `{ keyHashHmac: <hmac>, keyHash: null }`; otherwise it falls back to `{ keyHashHmac: null, keyHash: <sha256> }`. The fallback means key creation never hard-fails just because a pepper isn't configured, though a fallback key is a legacy SHA-256 key.
 
 ### Verifying
 
@@ -66,23 +66,23 @@ if (!row) {
 }
 ```
 
-Verify **HMAC first, then fall back to SHA-256** so keys minted before the migration keep working through the cutover window. This is exactly what the facilitator's auth middleware does.
+Verify **HMAC first, then fall back to SHA-256**, so keys minted before the migration keep working through the cutover window. This is exactly what the facilitator's auth middleware does.
 
-- `apiKeyHashHmac(rawKey, pepper)` → `HMAC-SHA256(pepper, rawKey)` hex. For new keys.
-- `apiKeyHashSha256(rawKey)` → legacy plain `SHA-256(rawKey)` hex. Fallback only.
-- `getApiKeyPepper(env?)` → returns `env.TOKEN_PEPPER`, or `null` if it's unset **or shorter than 32 characters**.
+- `apiKeyHashHmac(rawKey, pepper)` returns `HMAC-SHA256(pepper, rawKey)` as hex, for new keys.
+- `apiKeyHashSha256(rawKey)` returns the legacy plain `SHA-256(rawKey)` hex, for fallback only.
+- `getApiKeyPepper(env?)` returns `env.TOKEN_PEPPER`, or `null` if it's unset **or shorter than 32 characters**.
 
 ### The TOKEN_PEPPER contract
 
-`TOKEN_PEPPER` is a server secret (≥ 32 chars) shared with `cli_sessions`. The critical operational rule: **every service that mints API keys - the facilitator, the dashboard, and any CLI/bootstrap script - must use the byte-for-byte identical `TOKEN_PEPPER`.** A key HMAC'd with one pepper will not match a lookup computed with a different one, so a mismatched dashboard would mint keys the facilitator rejects. When the pepper is absent everywhere, everything degrades gracefully to SHA-256.
+`TOKEN_PEPPER` is a server secret (at least 32 chars) shared with `cli_sessions`. The critical operational rule is that **every service that mints API keys (the facilitator, the dashboard, and any CLI/bootstrap script) must use the byte-for-byte identical `TOKEN_PEPPER`.** A key HMAC'd with one pepper will not match a lookup computed with a different one, so a mismatched dashboard would mint keys the facilitator rejects. When the pepper is absent everywhere, everything degrades gracefully to SHA-256.
 
 Once the pepper is deployed everywhere and the migration window has passed, `apps/facilitator/scripts/api-keys-migrate-cleanup.mts` revokes the leftover SHA-256-only keys (dry-run first; default 60-day window) and writes an audit event per revocation.
 
 ## Schema exports
 
-The package exports Drizzle table objects you query/insert against: `merchants`, `apiKeys`, `paywalls`, `transactions`, `agents`, `webhookDeliveries`, `complianceEvents`, `cliSessions`, `auditEvents` - plus `environmentEnum` and its `Environment` (`"live" | "test"`) type. See the [`@pincerpay/db` README](https://github.com/ds1/pincerpay/tree/master/packages/db) for column-level detail.
+The package exports Drizzle table objects you query and insert against: `merchants`, `apiKeys`, `paywalls`, `transactions`, `agents`, `webhookDeliveries`, `complianceEvents`, `cliSessions`, and `auditEvents`. It also exports `environmentEnum` and its `Environment` (`"live" | "test"`) type. See the [`@pincerpay/db` README](https://github.com/ds1/pincerpay/tree/master/packages/db) for column-level detail.
 
-> **After `db:push`, re-enable RLS.** `drizzle-kit push` recreates tables without RLS policies; PincerPay's security model relies on RLS being on. Re-apply it after any push.
+> **After `db:push`, re-enable RLS.** `drizzle-kit push` recreates tables without RLS policies, and PincerPay's security model relies on RLS being on, so re-apply it after any push.
 
 ## Where next
 

--- a/apps/dashboard/content/docs/guide-db.md
+++ b/apps/dashboard/content/docs/guide-db.md
@@ -1,0 +1,89 @@
+---
+title: "Database & Key Hashing Functions"
+description: "Implementation guide to @pincerpay/db — the connection factory, the API-key hashing helpers, and the TOKEN_PEPPER rule that keeps keys verifiable across services."
+order: 3.95
+section: SDK Guides
+---
+
+`@pincerpay/db` is the Drizzle ORM schema and Postgres client behind PincerPay. Most teams consume it indirectly (via the facilitator, dashboard, or `@pincerpay/onboarding`), but its connection factory and — new in 0.3.0 — its API-key hashing helpers are the canonical building blocks for anything that touches merchants, keys, or transactions directly. This guide covers each, plus the cross-service `TOKEN_PEPPER` contract.
+
+> **ESM-only, server-side.** It uses the Node `postgres` driver and `node:crypto`; it never belongs in a browser bundle. Two entry points: `@pincerpay/db` (client + hashing + schema) and `@pincerpay/db/schema` (schema only).
+
+## `createDb(connectionString, options?)` — the connection factory
+
+```ts
+import { createDb, transactions } from "@pincerpay/db";
+import { eq } from "drizzle-orm";
+
+const { db, close } = createDb(process.env.DATABASE_URL!);
+try {
+  const rows = await db.select().from(transactions)
+    .where(eq(transactions.merchantId, id)).limit(10);
+} finally {
+  await close(); // ALWAYS close — especially in serverless
+}
+```
+
+Returns `{ db, close }` where `db` is a Drizzle instance bound to the full schema and `close()` ends the underlying pool. The `Database` type is exported for typing functions that accept the client (`db: Database`).
+
+It adapts to your connection automatically:
+
+- `{ serverless: true }` caps the pool at `max: 1` (right for Vercel/Lambda); the default is `max: 10`.
+- **Pooler detection:** if the connection string contains `:6543` (Supabase's transaction pooler) it disables prepared statements (`prepare: false`) and requires TLS (`ssl: "require"`). A direct `:5432` connection uses `prepare: true`, `ssl: false`. So point serverless code at the `:6543` pooler URL and long-lived services at `:5432` — `createDb` does the rest.
+
+The one rule: **call `close()`** when you're done (or on shutdown). Leaked pools are the classic serverless failure.
+
+## API-key hashing helpers
+
+API keys are never stored in plaintext. As of migration `0004`, PincerPay hashes them with **HMAC-SHA256 + a server pepper** (matching `cli_sessions`), with a legacy SHA-256 path for backward compatibility. Use these helpers at every mint and verify site so the scheme stays consistent — don't re-implement hashing inline.
+
+### Minting
+
+```ts
+import { hashNewApiKey, apiKeys } from "@pincerpay/db";
+
+const { keyHash, keyHashHmac } = hashNewApiKey(rawKey); // reads TOKEN_PEPPER from env
+await db.insert(apiKeys).values({ merchantId, keyHash, keyHashHmac, prefix, label, environment });
+```
+
+`hashNewApiKey(rawKey, env?)` returns a `MintedApiKeyHash` with **exactly one** column populated: if a pepper is available it returns `{ keyHashHmac: <hmac>, keyHash: null }`; otherwise it falls back to `{ keyHashHmac: null, keyHash: <sha256> }`. The fallback means key creation never hard-fails just because a pepper isn't configured — but a fallback key is a legacy SHA-256 key.
+
+### Verifying
+
+```ts
+import { apiKeyHashHmac, apiKeyHashSha256, getApiKeyPepper, apiKeys } from "@pincerpay/db";
+import { and, eq } from "drizzle-orm";
+
+const pepper = getApiKeyPepper();          // string | null
+let row;
+if (pepper) {
+  [row] = await db.select().from(apiKeys)
+    .where(and(eq(apiKeys.keyHashHmac, apiKeyHashHmac(rawKey, pepper)), eq(apiKeys.isActive, true))).limit(1);
+}
+if (!row) {
+  [row] = await db.select().from(apiKeys)
+    .where(and(eq(apiKeys.keyHash, apiKeyHashSha256(rawKey)), eq(apiKeys.isActive, true))).limit(1);
+}
+```
+
+Verify **HMAC first, then fall back to SHA-256** so keys minted before the migration keep working through the cutover window. This is exactly what the facilitator's auth middleware does.
+
+- `apiKeyHashHmac(rawKey, pepper)` → `HMAC-SHA256(pepper, rawKey)` hex. For new keys.
+- `apiKeyHashSha256(rawKey)` → legacy plain `SHA-256(rawKey)` hex. Fallback only.
+- `getApiKeyPepper(env?)` → returns `env.TOKEN_PEPPER`, or `null` if it's unset **or shorter than 32 characters**.
+
+### The TOKEN_PEPPER contract
+
+`TOKEN_PEPPER` is a server secret (≥ 32 chars) shared with `cli_sessions`. The critical operational rule: **every service that mints API keys — the facilitator, the dashboard, and any CLI/bootstrap script — must use the byte-for-byte identical `TOKEN_PEPPER`.** A key HMAC'd with one pepper will not match a lookup computed with a different one, so a mismatched dashboard would mint keys the facilitator rejects. When the pepper is absent everywhere, everything degrades gracefully to SHA-256.
+
+Once the pepper is deployed everywhere and the migration window has passed, `apps/facilitator/scripts/api-keys-migrate-cleanup.mts` revokes the leftover SHA-256-only keys (dry-run first; default 60-day window) and writes an audit event per revocation.
+
+## Schema exports
+
+The package exports Drizzle table objects you query/insert against: `merchants`, `apiKeys`, `paywalls`, `transactions`, `agents`, `webhookDeliveries`, `complianceEvents`, `cliSessions`, `auditEvents` — plus `environmentEnum` and its `Environment` (`"live" | "test"`) type. See the [`@pincerpay/db` README](https://github.com/ds1/pincerpay/tree/master/packages/db) for column-level detail.
+
+> **After `db:push`, re-enable RLS.** `drizzle-kit push` recreates tables without RLS policies; PincerPay's security model relies on RLS being on. Re-apply it after any push.
+
+## Where next
+
+The [Onboarding guide](/docs/guide-onboarding) mints keys through `hashNewApiKey`, and the [error reference](/docs/error-reference) documents the auth lookup from the agent's perspective.

--- a/apps/dashboard/content/docs/guide-db.md
+++ b/apps/dashboard/content/docs/guide-db.md
@@ -1,15 +1,15 @@
 ---
 title: "Database & Key Hashing Functions"
-description: "Implementation guide to @pincerpay/db — the connection factory, the API-key hashing helpers, and the TOKEN_PEPPER rule that keeps keys verifiable across services."
+description: "Implementation guide to @pincerpay/db - the connection factory, the API-key hashing helpers, and the TOKEN_PEPPER rule that keeps keys verifiable across services."
 order: 3.95
 section: SDK Guides
 ---
 
-`@pincerpay/db` is the Drizzle ORM schema and Postgres client behind PincerPay. Most teams consume it indirectly (via the facilitator, dashboard, or `@pincerpay/onboarding`), but its connection factory and — new in 0.3.0 — its API-key hashing helpers are the canonical building blocks for anything that touches merchants, keys, or transactions directly. This guide covers each, plus the cross-service `TOKEN_PEPPER` contract.
+`@pincerpay/db` is the Drizzle ORM schema and Postgres client behind PincerPay. Most teams consume it indirectly (via the facilitator, dashboard, or `@pincerpay/onboarding`), but its connection factory and - new in 0.3.0 - its API-key hashing helpers are the canonical building blocks for anything that touches merchants, keys, or transactions directly. This guide covers each, plus the cross-service `TOKEN_PEPPER` contract.
 
 > **ESM-only, server-side.** It uses the Node `postgres` driver and `node:crypto`; it never belongs in a browser bundle. Two entry points: `@pincerpay/db` (client + hashing + schema) and `@pincerpay/db/schema` (schema only).
 
-## `createDb(connectionString, options?)` — the connection factory
+## `createDb(connectionString, options?)` - the connection factory
 
 ```ts
 import { createDb, transactions } from "@pincerpay/db";
@@ -20,7 +20,7 @@ try {
   const rows = await db.select().from(transactions)
     .where(eq(transactions.merchantId, id)).limit(10);
 } finally {
-  await close(); // ALWAYS close — especially in serverless
+  await close(); // ALWAYS close - especially in serverless
 }
 ```
 
@@ -29,13 +29,13 @@ Returns `{ db, close }` where `db` is a Drizzle instance bound to the full schem
 It adapts to your connection automatically:
 
 - `{ serverless: true }` caps the pool at `max: 1` (right for Vercel/Lambda); the default is `max: 10`.
-- **Pooler detection:** if the connection string contains `:6543` (Supabase's transaction pooler) it disables prepared statements (`prepare: false`) and requires TLS (`ssl: "require"`). A direct `:5432` connection uses `prepare: true`, `ssl: false`. So point serverless code at the `:6543` pooler URL and long-lived services at `:5432` — `createDb` does the rest.
+- **Pooler detection:** if the connection string contains `:6543` (Supabase's transaction pooler) it disables prepared statements (`prepare: false`) and requires TLS (`ssl: "require"`). A direct `:5432` connection uses `prepare: true`, `ssl: false`. So point serverless code at the `:6543` pooler URL and long-lived services at `:5432` - `createDb` does the rest.
 
 The one rule: **call `close()`** when you're done (or on shutdown). Leaked pools are the classic serverless failure.
 
 ## API-key hashing helpers
 
-API keys are never stored in plaintext. As of migration `0004`, PincerPay hashes them with **HMAC-SHA256 + a server pepper** (matching `cli_sessions`), with a legacy SHA-256 path for backward compatibility. Use these helpers at every mint and verify site so the scheme stays consistent — don't re-implement hashing inline.
+API keys are never stored in plaintext. As of migration `0004`, PincerPay hashes them with **HMAC-SHA256 + a server pepper** (matching `cli_sessions`), with a legacy SHA-256 path for backward compatibility. Use these helpers at every mint and verify site so the scheme stays consistent - don't re-implement hashing inline.
 
 ### Minting
 
@@ -46,7 +46,7 @@ const { keyHash, keyHashHmac } = hashNewApiKey(rawKey); // reads TOKEN_PEPPER fr
 await db.insert(apiKeys).values({ merchantId, keyHash, keyHashHmac, prefix, label, environment });
 ```
 
-`hashNewApiKey(rawKey, env?)` returns a `MintedApiKeyHash` with **exactly one** column populated: if a pepper is available it returns `{ keyHashHmac: <hmac>, keyHash: null }`; otherwise it falls back to `{ keyHashHmac: null, keyHash: <sha256> }`. The fallback means key creation never hard-fails just because a pepper isn't configured — but a fallback key is a legacy SHA-256 key.
+`hashNewApiKey(rawKey, env?)` returns a `MintedApiKeyHash` with **exactly one** column populated: if a pepper is available it returns `{ keyHashHmac: <hmac>, keyHash: null }`; otherwise it falls back to `{ keyHashHmac: null, keyHash: <sha256> }`. The fallback means key creation never hard-fails just because a pepper isn't configured - but a fallback key is a legacy SHA-256 key.
 
 ### Verifying
 
@@ -74,13 +74,13 @@ Verify **HMAC first, then fall back to SHA-256** so keys minted before the migra
 
 ### The TOKEN_PEPPER contract
 
-`TOKEN_PEPPER` is a server secret (≥ 32 chars) shared with `cli_sessions`. The critical operational rule: **every service that mints API keys — the facilitator, the dashboard, and any CLI/bootstrap script — must use the byte-for-byte identical `TOKEN_PEPPER`.** A key HMAC'd with one pepper will not match a lookup computed with a different one, so a mismatched dashboard would mint keys the facilitator rejects. When the pepper is absent everywhere, everything degrades gracefully to SHA-256.
+`TOKEN_PEPPER` is a server secret (≥ 32 chars) shared with `cli_sessions`. The critical operational rule: **every service that mints API keys - the facilitator, the dashboard, and any CLI/bootstrap script - must use the byte-for-byte identical `TOKEN_PEPPER`.** A key HMAC'd with one pepper will not match a lookup computed with a different one, so a mismatched dashboard would mint keys the facilitator rejects. When the pepper is absent everywhere, everything degrades gracefully to SHA-256.
 
 Once the pepper is deployed everywhere and the migration window has passed, `apps/facilitator/scripts/api-keys-migrate-cleanup.mts` revokes the leftover SHA-256-only keys (dry-run first; default 60-day window) and writes an audit event per revocation.
 
 ## Schema exports
 
-The package exports Drizzle table objects you query/insert against: `merchants`, `apiKeys`, `paywalls`, `transactions`, `agents`, `webhookDeliveries`, `complianceEvents`, `cliSessions`, `auditEvents` — plus `environmentEnum` and its `Environment` (`"live" | "test"`) type. See the [`@pincerpay/db` README](https://github.com/ds1/pincerpay/tree/master/packages/db) for column-level detail.
+The package exports Drizzle table objects you query/insert against: `merchants`, `apiKeys`, `paywalls`, `transactions`, `agents`, `webhookDeliveries`, `complianceEvents`, `cliSessions`, `auditEvents` - plus `environmentEnum` and its `Environment` (`"live" | "test"`) type. See the [`@pincerpay/db` README](https://github.com/ds1/pincerpay/tree/master/packages/db) for column-level detail.
 
 > **After `db:push`, re-enable RLS.** `drizzle-kit push` recreates tables without RLS policies; PincerPay's security model relies on RLS being on. Re-apply it after any push.
 

--- a/apps/dashboard/content/docs/guide-merchant.md
+++ b/apps/dashboard/content/docs/guide-merchant.md
@@ -1,0 +1,104 @@
+---
+title: "Merchant SDK Functions"
+description: "Implementation guide to @pincerpay/merchant — the Next.js paywall middleware, the low-level facilitator client, and the amount/chain helpers."
+order: 3.8
+section: SDK Guides
+---
+
+`@pincerpay/merchant` is how a merchant accepts agent payments: wrap your routes in middleware that returns `402` until a valid USDC payment arrives, then let the request through. The package has two entry points and five exports. This guide covers each, including the startup-time validation that will throw before your server ever serves a request.
+
+> **ESM-only, server-side.** Two entry points: `@pincerpay/merchant` (helpers + client) and `@pincerpay/merchant/nextjs` (the middleware). There is **no Express or Hono adapter** — those were removed; the Next.js middleware is hono-compatible and is the supported path.
+
+## `createPincerPayMiddleware(config)` — the paywall
+
+```ts
+import { Hono } from "hono";
+import { createPincerPayMiddleware } from "@pincerpay/merchant/nextjs";
+
+const app = new Hono();
+app.use("*", createPincerPayMiddleware({
+  apiKey: process.env.PINCERPAY_API_KEY!,
+  merchantAddresses: { solana: process.env.MERCHANT_ADDRESS_SOLANA! },
+  routes: {
+    "GET /api/research/:id": { price: "0.05", chain: "solana" },
+    "POST /api/summarize":   { price: "0.25", chains: ["solana", "base"] },
+  },
+}));
+```
+
+It returns an async hono-style middleware `(c, next) => ...`. The `config` is a `PincerPayConfig` (imported from `@pincerpay/core` if you want the type):
+
+| Field | Required | Notes |
+|---|---|---|
+| `apiKey` | ✅ | Sent as the `x-pincerpay-api-key` header to the facilitator |
+| `routes` | ✅ | Keyed by `"METHOD /path"`, e.g. `"GET /api/weather"` → `RoutePaywallConfig` |
+| `merchantAddress` | — | Legacy single receive wallet / fallback |
+| `merchantAddresses` | — | Per-chain wallets, keyed by chain shorthand (case-insensitive), wins over `merchantAddress` |
+| `facilitatorUrl` | — | Defaults to production; a trailing `/v1` is stripped automatically |
+| `syncFacilitatorOnStart` | — | **Currently a no-op** — declared in the type but not read; the middleware always fetches `/v1/supported` at init regardless |
+
+One of `merchantAddress` / `merchantAddresses` must be present. Each `RoutePaywallConfig` has a `price` (a **human USDC decimal string** like `"0.01"` — the middleware converts it to base units for you), plus `chain?`, `chains?`, and `description?`. **If you specify neither `chain` nor `chains`, the route defaults to `["solana"]`.**
+
+### It validates eagerly — at `createPincerPayMiddleware()` time
+
+Before serving anything, for every route × chain the middleware calls `resolveChain`, `resolveMerchantAddress`, and `validateMerchantAddressForChain`. Any of these throws synchronously, so a misconfiguration fails fast at boot:
+
+- `Unknown chain: <x>` — a route names a chain that isn't recognized.
+- a missing-address throw — you paywalled a chain you have no wallet for.
+- a format throw — a configured address fails the Solana base58 / EVM `0x`+40hex check.
+
+This is a feature: you learn about a broken config at deploy, not when an agent gets a 500.
+
+### The request lifecycle
+
+- Path/method **doesn't match** a route → `next()` (free passthrough).
+- Matches, **no payment header** (`payment-signature` or `x-payment`) → **HTTP 402** with a JSON body (`x402Version`, `error`, `resource`, `accepts`, `extensions`) and a base64 `payment-required` header describing accepted assets.
+- Matches **with a payment header** → the middleware POSTs to the facilitator's `/v1/settle`. On `success: false` it returns **402** `{ error: "Payment settlement failed", reason, message }`. On success it sets `c.set("pincerpay", paymentInfo)`, adds a base64 `payment-response` header, and calls `next()`.
+- An unexpected error → **HTTP 500** `{ error: "Payment processing failed", detail }`.
+
+After payment, read the verified result in your handler:
+
+```ts
+import type { PincerPayContextVariables } from "@pincerpay/merchant/nextjs";
+
+const app = new Hono<{ Variables: PincerPayContextVariables }>();
+app.get("/api/research/:id", (c) => {
+  const { payer, transaction, network } = c.get("pincerpay"); // PincerPayPaymentInfo
+  // `payer` is the verified payer from the facilitator's settle response — not the raw request header.
+  return c.json({ data: "..." });
+});
+```
+
+`PincerPayPaymentInfo` is `{ payer: string; transaction: string; network: string }` (`network` is the CAIP-2 ID). It and `PincerPayContextVariables` are re-exported from `@pincerpay/merchant/nextjs`.
+
+## `PincerPayClient` — the low-level facilitator client
+
+When you want to drive the facilitator directly (custom frameworks, server-to-server verification) instead of using the middleware:
+
+```ts
+import { PincerPayClient } from "@pincerpay/merchant";
+
+const client = new PincerPayClient({ apiKey, merchantAddresses });
+await client.verify(paymentPayload, paymentRequirements); // POST /v1/verify
+await client.settle(paymentPayload, paymentRequirements); // POST /v1/settle
+await client.getSupported();                              // GET  /v1/supported
+await client.getStatus(txHash);                           // GET  /v1/status/:txHash
+```
+
+The constructor takes a `PincerPayConfig` and exposes readonly `facilitatorUrl`, `apiKey`, `merchantAddress?`, `merchantAddresses?`. Every method sends the API-key header and returns the parsed JSON as `unknown` (you cast/validate). On any non-2xx response they **throw** `Error("Facilitator <path> failed (<status>): <body>")`, so wrap calls in try/catch. Note one asymmetry: the client does **not** strip a trailing `/v1` from `facilitatorUrl` the way the middleware does — pass the bare origin.
+
+## Amount & chain helpers
+
+```ts
+import { toBaseUnits, resolveRouteChains, getUsdcAsset } from "@pincerpay/merchant";
+
+toBaseUnits("0.01");              // → "10000"  (human USDC → 6-decimal base units; truncates extra decimals; non-numeric throws)
+resolveRouteChains(routeConfig);  // → CAIP-2 IDs for the route; defaults to ["solana"] when unset
+getUsdcAsset("polygon");          // → the USDC contract address for that chain; throws "Unknown chain: <x>" if unresolved
+```
+
+`toBaseUnits` is the conversion the middleware applies to `price` for you — reach for it when you mint your own paywall payloads.
+
+## Where next
+
+The middleware leans entirely on [`@pincerpay/core`](/docs/guide-core) for chain/address resolution, so its startup throws are really core's validators talking. For the conceptual end-to-end flow, see the [Merchant SDK overview](/docs/merchant-sdk) and [Quickstart: Merchant](/docs/quickstart-merchant).

--- a/apps/dashboard/content/docs/guide-merchant.md
+++ b/apps/dashboard/content/docs/guide-merchant.md
@@ -1,15 +1,15 @@
 ---
 title: "Merchant SDK Functions"
-description: "Implementation guide to @pincerpay/merchant — the Next.js paywall middleware, the low-level facilitator client, and the amount/chain helpers."
+description: "Implementation guide to @pincerpay/merchant - the Next.js paywall middleware, the low-level facilitator client, and the amount/chain helpers."
 order: 3.8
 section: SDK Guides
 ---
 
 `@pincerpay/merchant` is how a merchant accepts agent payments: wrap your routes in middleware that returns `402` until a valid USDC payment arrives, then let the request through. The package has two entry points and five exports. This guide covers each, including the startup-time validation that will throw before your server ever serves a request.
 
-> **ESM-only, server-side.** Two entry points: `@pincerpay/merchant` (helpers + client) and `@pincerpay/merchant/nextjs` (the middleware). There is **no Express or Hono adapter** — those were removed; the Next.js middleware is hono-compatible and is the supported path.
+> **ESM-only, server-side.** Two entry points: `@pincerpay/merchant` (helpers + client) and `@pincerpay/merchant/nextjs` (the middleware). There is **no Express or Hono adapter** - those were removed; the Next.js middleware is hono-compatible and is the supported path.
 
-## `createPincerPayMiddleware(config)` — the paywall
+## `createPincerPayMiddleware(config)` - the paywall
 
 ```ts
 import { Hono } from "hono";
@@ -32,20 +32,20 @@ It returns an async hono-style middleware `(c, next) => ...`. The `config` is a 
 |---|---|---|
 | `apiKey` | ✅ | Sent as the `x-pincerpay-api-key` header to the facilitator |
 | `routes` | ✅ | Keyed by `"METHOD /path"`, e.g. `"GET /api/weather"` → `RoutePaywallConfig` |
-| `merchantAddress` | — | Legacy single receive wallet / fallback |
-| `merchantAddresses` | — | Per-chain wallets, keyed by chain shorthand (case-insensitive), wins over `merchantAddress` |
-| `facilitatorUrl` | — | Defaults to production; a trailing `/v1` is stripped automatically |
-| `syncFacilitatorOnStart` | — | **Currently a no-op** — declared in the type but not read; the middleware always fetches `/v1/supported` at init regardless |
+| `merchantAddress` | - | Legacy single receive wallet / fallback |
+| `merchantAddresses` | - | Per-chain wallets, keyed by chain shorthand (case-insensitive), wins over `merchantAddress` |
+| `facilitatorUrl` | - | Defaults to production; a trailing `/v1` is stripped automatically |
+| `syncFacilitatorOnStart` | - | **Currently a no-op** - declared in the type but not read; the middleware always fetches `/v1/supported` at init regardless |
 
-One of `merchantAddress` / `merchantAddresses` must be present. Each `RoutePaywallConfig` has a `price` (a **human USDC decimal string** like `"0.01"` — the middleware converts it to base units for you), plus `chain?`, `chains?`, and `description?`. **If you specify neither `chain` nor `chains`, the route defaults to `["solana"]`.**
+One of `merchantAddress` / `merchantAddresses` must be present. Each `RoutePaywallConfig` has a `price` (a **human USDC decimal string** like `"0.01"` - the middleware converts it to base units for you), plus `chain?`, `chains?`, and `description?`. **If you specify neither `chain` nor `chains`, the route defaults to `["solana"]`.**
 
-### It validates eagerly — at `createPincerPayMiddleware()` time
+### It validates eagerly - at `createPincerPayMiddleware()` time
 
 Before serving anything, for every route × chain the middleware calls `resolveChain`, `resolveMerchantAddress`, and `validateMerchantAddressForChain`. Any of these throws synchronously, so a misconfiguration fails fast at boot:
 
-- `Unknown chain: <x>` — a route names a chain that isn't recognized.
-- a missing-address throw — you paywalled a chain you have no wallet for.
-- a format throw — a configured address fails the Solana base58 / EVM `0x`+40hex check.
+- `Unknown chain: <x>` - a route names a chain that isn't recognized.
+- a missing-address throw - you paywalled a chain you have no wallet for.
+- a format throw - a configured address fails the Solana base58 / EVM `0x`+40hex check.
 
 This is a feature: you learn about a broken config at deploy, not when an agent gets a 500.
 
@@ -64,14 +64,14 @@ import type { PincerPayContextVariables } from "@pincerpay/merchant/nextjs";
 const app = new Hono<{ Variables: PincerPayContextVariables }>();
 app.get("/api/research/:id", (c) => {
   const { payer, transaction, network } = c.get("pincerpay"); // PincerPayPaymentInfo
-  // `payer` is the verified payer from the facilitator's settle response — not the raw request header.
+  // `payer` is the verified payer from the facilitator's settle response - not the raw request header.
   return c.json({ data: "..." });
 });
 ```
 
 `PincerPayPaymentInfo` is `{ payer: string; transaction: string; network: string }` (`network` is the CAIP-2 ID). It and `PincerPayContextVariables` are re-exported from `@pincerpay/merchant/nextjs`.
 
-## `PincerPayClient` — the low-level facilitator client
+## `PincerPayClient` - the low-level facilitator client
 
 When you want to drive the facilitator directly (custom frameworks, server-to-server verification) instead of using the middleware:
 
@@ -85,7 +85,7 @@ await client.getSupported();                              // GET  /v1/supported
 await client.getStatus(txHash);                           // GET  /v1/status/:txHash
 ```
 
-The constructor takes a `PincerPayConfig` and exposes readonly `facilitatorUrl`, `apiKey`, `merchantAddress?`, `merchantAddresses?`. Every method sends the API-key header and returns the parsed JSON as `unknown` (you cast/validate). On any non-2xx response they **throw** `Error("Facilitator <path> failed (<status>): <body>")`, so wrap calls in try/catch. Note one asymmetry: the client does **not** strip a trailing `/v1` from `facilitatorUrl` the way the middleware does — pass the bare origin.
+The constructor takes a `PincerPayConfig` and exposes readonly `facilitatorUrl`, `apiKey`, `merchantAddress?`, `merchantAddresses?`. Every method sends the API-key header and returns the parsed JSON as `unknown` (you cast/validate). On any non-2xx response they **throw** `Error("Facilitator <path> failed (<status>): <body>")`, so wrap calls in try/catch. Note one asymmetry: the client does **not** strip a trailing `/v1` from `facilitatorUrl` the way the middleware does - pass the bare origin.
 
 ## Amount & chain helpers
 
@@ -97,7 +97,7 @@ resolveRouteChains(routeConfig);  // → CAIP-2 IDs for the route; defaults to [
 getUsdcAsset("polygon");          // → the USDC contract address for that chain; throws "Unknown chain: <x>" if unresolved
 ```
 
-`toBaseUnits` is the conversion the middleware applies to `price` for you — reach for it when you mint your own paywall payloads.
+`toBaseUnits` is the conversion the middleware applies to `price` for you - reach for it when you mint your own paywall payloads.
 
 ## Where next
 

--- a/apps/dashboard/content/docs/guide-merchant.md
+++ b/apps/dashboard/content/docs/guide-merchant.md
@@ -1,15 +1,15 @@
 ---
 title: "Merchant SDK Functions"
-description: "Implementation guide to @pincerpay/merchant - the Next.js paywall middleware, the low-level facilitator client, and the amount/chain helpers."
+description: "Implementation guide to @pincerpay/merchant: the Next.js paywall middleware, the low-level facilitator client, and the amount/chain helpers."
 order: 3.8
 section: SDK Guides
 ---
 
 `@pincerpay/merchant` is how a merchant accepts agent payments: wrap your routes in middleware that returns `402` until a valid USDC payment arrives, then let the request through. The package has two entry points and five exports. This guide covers each, including the startup-time validation that will throw before your server ever serves a request.
 
-> **ESM-only, server-side.** Two entry points: `@pincerpay/merchant` (helpers + client) and `@pincerpay/merchant/nextjs` (the middleware). There is **no Express or Hono adapter** - those were removed; the Next.js middleware is hono-compatible and is the supported path.
+> **ESM-only, server-side.** Two entry points: `@pincerpay/merchant` (helpers + client) and `@pincerpay/merchant/nextjs` (the middleware). There is **no Express or Hono adapter**; those were removed. The Next.js middleware is hono-compatible and is the supported path.
 
-## `createPincerPayMiddleware(config)` - the paywall
+## `createPincerPayMiddleware(config)`: the paywall
 
 ```ts
 import { Hono } from "hono";
@@ -26,35 +26,35 @@ app.use("*", createPincerPayMiddleware({
 }));
 ```
 
-It returns an async hono-style middleware `(c, next) => ...`. The `config` is a `PincerPayConfig` (imported from `@pincerpay/core` if you want the type):
+It returns an async hono-style middleware `(c, next) => ...`. The `config` is a `PincerPayConfig`, which you can import from `@pincerpay/core` if you want the type:
 
 | Field | Required | Notes |
 |---|---|---|
-| `apiKey` | ✅ | Sent as the `x-pincerpay-api-key` header to the facilitator |
-| `routes` | ✅ | Keyed by `"METHOD /path"`, e.g. `"GET /api/weather"` → `RoutePaywallConfig` |
-| `merchantAddress` | - | Legacy single receive wallet / fallback |
-| `merchantAddresses` | - | Per-chain wallets, keyed by chain shorthand (case-insensitive), wins over `merchantAddress` |
-| `facilitatorUrl` | - | Defaults to production; a trailing `/v1` is stripped automatically |
-| `syncFacilitatorOnStart` | - | **Currently a no-op** - declared in the type but not read; the middleware always fetches `/v1/supported` at init regardless |
+| `apiKey` | Yes | Sent as the `x-pincerpay-api-key` header to the facilitator |
+| `routes` | Yes | Keyed by `"METHOD /path"`, e.g. `"GET /api/weather"` → `RoutePaywallConfig` |
+| `merchantAddress` | No | Legacy single receive wallet / fallback |
+| `merchantAddresses` | No | Per-chain wallets, keyed by chain shorthand (case-insensitive), wins over `merchantAddress` |
+| `facilitatorUrl` | No | Defaults to production; a trailing `/v1` is stripped automatically |
+| `syncFacilitatorOnStart` | No | Currently a no-op: declared in the type but not read, since the middleware always fetches `/v1/supported` at init regardless |
 
-One of `merchantAddress` / `merchantAddresses` must be present. Each `RoutePaywallConfig` has a `price` (a **human USDC decimal string** like `"0.01"` - the middleware converts it to base units for you), plus `chain?`, `chains?`, and `description?`. **If you specify neither `chain` nor `chains`, the route defaults to `["solana"]`.**
+One of `merchantAddress` / `merchantAddresses` must be present. Each `RoutePaywallConfig` has a `price` (a **human USDC decimal string** like `"0.01"`, which the middleware converts to base units for you), plus `chain?`, `chains?`, and `description?`. **If you specify neither `chain` nor `chains`, the route defaults to `["solana"]`.**
 
-### It validates eagerly - at `createPincerPayMiddleware()` time
+### Eager validation, at `createPincerPayMiddleware()` time
 
 Before serving anything, for every route × chain the middleware calls `resolveChain`, `resolveMerchantAddress`, and `validateMerchantAddressForChain`. Any of these throws synchronously, so a misconfiguration fails fast at boot:
 
-- `Unknown chain: <x>` - a route names a chain that isn't recognized.
-- a missing-address throw - you paywalled a chain you have no wallet for.
-- a format throw - a configured address fails the Solana base58 / EVM `0x`+40hex check.
+- `Unknown chain: <x>`: a route names a chain that isn't recognized.
+- a missing-address throw: you paywalled a chain you have no wallet for.
+- a format throw: a configured address fails the Solana base58 or EVM `0x`+40hex check.
 
 This is a feature: you learn about a broken config at deploy, not when an agent gets a 500.
 
 ### The request lifecycle
 
-- Path/method **doesn't match** a route → `next()` (free passthrough).
-- Matches, **no payment header** (`payment-signature` or `x-payment`) → **HTTP 402** with a JSON body (`x402Version`, `error`, `resource`, `accepts`, `extensions`) and a base64 `payment-required` header describing accepted assets.
-- Matches **with a payment header** → the middleware POSTs to the facilitator's `/v1/settle`. On `success: false` it returns **402** `{ error: "Payment settlement failed", reason, message }`. On success it sets `c.set("pincerpay", paymentInfo)`, adds a base64 `payment-response` header, and calls `next()`.
-- An unexpected error → **HTTP 500** `{ error: "Payment processing failed", detail }`.
+- When the path/method **doesn't match** a route, the middleware calls `next()` (free passthrough).
+- When it matches but there's **no payment header** (`payment-signature` or `x-payment`), it returns **HTTP 402** with a JSON body (`x402Version`, `error`, `resource`, `accepts`, `extensions`) and a base64 `payment-required` header describing accepted assets.
+- When it matches **with a payment header**, it POSTs to the facilitator's `/v1/settle`. On `success: false` it returns **402** `{ error: "Payment settlement failed", reason, message }`. On success it sets `c.set("pincerpay", paymentInfo)`, adds a base64 `payment-response` header, and calls `next()`.
+- On an unexpected error it returns **HTTP 500** `{ error: "Payment processing failed", detail }`.
 
 After payment, read the verified result in your handler:
 
@@ -64,14 +64,14 @@ import type { PincerPayContextVariables } from "@pincerpay/merchant/nextjs";
 const app = new Hono<{ Variables: PincerPayContextVariables }>();
 app.get("/api/research/:id", (c) => {
   const { payer, transaction, network } = c.get("pincerpay"); // PincerPayPaymentInfo
-  // `payer` is the verified payer from the facilitator's settle response - not the raw request header.
+  // `payer` is the verified payer from the facilitator's settle response, not the raw request header.
   return c.json({ data: "..." });
 });
 ```
 
 `PincerPayPaymentInfo` is `{ payer: string; transaction: string; network: string }` (`network` is the CAIP-2 ID). It and `PincerPayContextVariables` are re-exported from `@pincerpay/merchant/nextjs`.
 
-## `PincerPayClient` - the low-level facilitator client
+## `PincerPayClient`: the low-level facilitator client
 
 When you want to drive the facilitator directly (custom frameworks, server-to-server verification) instead of using the middleware:
 
@@ -85,7 +85,7 @@ await client.getSupported();                              // GET  /v1/supported
 await client.getStatus(txHash);                           // GET  /v1/status/:txHash
 ```
 
-The constructor takes a `PincerPayConfig` and exposes readonly `facilitatorUrl`, `apiKey`, `merchantAddress?`, `merchantAddresses?`. Every method sends the API-key header and returns the parsed JSON as `unknown` (you cast/validate). On any non-2xx response they **throw** `Error("Facilitator <path> failed (<status>): <body>")`, so wrap calls in try/catch. Note one asymmetry: the client does **not** strip a trailing `/v1` from `facilitatorUrl` the way the middleware does - pass the bare origin.
+The constructor takes a `PincerPayConfig` and exposes readonly `facilitatorUrl`, `apiKey`, `merchantAddress?`, `merchantAddresses?`. Every method sends the API-key header and returns the parsed JSON as `unknown`, so you cast or validate it yourself. On any non-2xx response they **throw** `Error("Facilitator <path> failed (<status>): <body>")`, so wrap calls in try/catch. Note one asymmetry: the client does **not** strip a trailing `/v1` from `facilitatorUrl` the way the middleware does, so pass the bare origin.
 
 ## Amount & chain helpers
 
@@ -97,8 +97,8 @@ resolveRouteChains(routeConfig);  // → CAIP-2 IDs for the route; defaults to [
 getUsdcAsset("polygon");          // → the USDC contract address for that chain; throws "Unknown chain: <x>" if unresolved
 ```
 
-`toBaseUnits` is the conversion the middleware applies to `price` for you - reach for it when you mint your own paywall payloads.
+`toBaseUnits` is the conversion the middleware applies to `price` for you, so reach for it when you mint your own paywall payloads.
 
 ## Where next
 
-The middleware leans entirely on [`@pincerpay/core`](/docs/guide-core) for chain/address resolution, so its startup throws are really core's validators talking. For the conceptual end-to-end flow, see the [Merchant SDK overview](/docs/merchant-sdk) and [Quickstart: Merchant](/docs/quickstart-merchant).
+The middleware leans entirely on [`@pincerpay/core`](/docs/guide-core) for chain and address resolution, so its startup throws are really core's validators talking. For the conceptual end-to-end flow, see the [Merchant SDK overview](/docs/merchant-sdk) and [Quickstart: Merchant](/docs/quickstart-merchant).

--- a/apps/dashboard/content/docs/guide-onboarding.md
+++ b/apps/dashboard/content/docs/guide-onboarding.md
@@ -1,15 +1,15 @@
 ---
 title: "Onboarding Functions"
-description: "Implementation guide to @pincerpay/onboarding - non-custodial wallet generation, one-call merchant bootstrap, and API key minting against your own database."
+description: "Implementation guide to @pincerpay/onboarding: non-custodial wallet generation, one-call merchant bootstrap, and API key minting against your own database."
 order: 3.9
 section: SDK Guides
 ---
 
-`@pincerpay/onboarding` is the programmatic version of what the `pincerpay` CLI does: generate non-custodial wallets, create a merchant row, and mint an API key - all against a database you control. It's for building your own signup flow or admin tooling. This guide covers each exported function and the non-custodial contract you're responsible for upholding.
+`@pincerpay/onboarding` is the programmatic version of what the `pincerpay` CLI does: generate non-custodial wallets, create a merchant row, and mint an API key, all against a database you control. It's for building your own signup flow or admin tooling. This guide covers each exported function and the non-custodial contract you're responsible for upholding.
 
 > **ESM-only.** The wallet generator runs anywhere Node crypto does; the merchant/key functions are **server-side** and open a Postgres connection. Three entry points: `@pincerpay/onboarding` (everything), `@pincerpay/onboarding/wallets`, and `@pincerpay/onboarding/merchant`.
 
-## `generateMerchantWallets(options?)` - local, non-custodial keys
+## `generateMerchantWallets(options?)`: local, non-custodial keys
 
 ```ts
 import { generateMerchantWallets } from "@pincerpay/onboarding";
@@ -29,13 +29,13 @@ interface MerchantWallets {
 }
 ```
 
-It derives a Solana key at `m/44'/501'/0'/0'` (Phantom-compatible) and an EVM key at `m/44'/60'/0'/0/0` (MetaMask-compatible) - both exported as `SOLANA_DERIVATION_PATH` / `EVM_DERIVATION_PATH`. A supplied `mnemonic` must be valid BIP-39 or it throws `"Invalid BIP-39 mnemonic"`; a degenerate EVM derivation throws `"EVM derivation produced no private key"`.
+It derives a Solana key at `m/44'/501'/0'/0'` (Phantom-compatible) and an EVM key at `m/44'/60'/0'/0/0` (MetaMask-compatible), both exported as `SOLANA_DERIVATION_PATH` and `EVM_DERIVATION_PATH`. A supplied `mnemonic` must be valid BIP-39 or it throws `"Invalid BIP-39 mnemonic"`; a degenerate EVM derivation throws `"EVM derivation produced no private key"`.
 
-> **Non-custodial contract.** This function returns the mnemonic and private keys to *you* and PincerPay never sees them. That's the whole point - and the responsibility. Display them once to the merchant, let them save the phrase, and discard from memory. Don't log them, don't persist them server-side. Only public addresses should ever leave the process.
+> **Non-custodial contract.** This function returns the mnemonic and private keys to *you*, and PincerPay never sees them. That's the whole point, and the responsibility. Display them once to the merchant, let them save the phrase, and discard from memory. Don't log them, don't persist them server-side. Only public addresses should ever leave the process.
 
-## `bootstrapMerchant(options)` - zero to merchant in one call
+## `bootstrapMerchant(options)`: zero to merchant in one call
 
-The end-to-end path: take (or generate) wallets, insert the merchant, mint a live API key, return env-ready output.
+The end-to-end path takes (or generates) wallets, inserts the merchant, mints a live API key, and returns env-ready output.
 
 ```ts
 import { generateMerchantWallets, bootstrapMerchant } from "@pincerpay/onboarding";
@@ -52,11 +52,11 @@ const result = await bootstrapMerchant({
 // result: { merchantId, walletsGenerated, wallets?, apiKey: { rawKey, prefix, label }, webhookSecret }
 ```
 
-Defaults worth knowing: `walletAddress` falls back to `wallets.solana.address`; `walletAddresses` defaults to `{ solana, evm }`; `supportedChains` defaults to `["solana", "polygon"]` when wallets are present (else `[]`); `apiKeyLabel` defaults to `"Bootstrap"`. The API key is always minted in the **`live`** environment. A live webhook secret (random 32-byte hex) is always generated; a test secret only if you pass `webhookUrlTest`.
+Defaults worth knowing: `walletAddress` falls back to `wallets.solana.address`; `walletAddresses` defaults to `{ solana, evm }`; `supportedChains` defaults to `["solana", "polygon"]` when wallets are present (else `[]`); `apiKeyLabel` defaults to `"Bootstrap"`. The API key is always minted in the **`live`** environment. A live webhook secret (random 32-byte hex) is always generated, and a test secret only if you pass `webhookUrlTest`.
 
-You must supply **either** generated `wallets` **or** an explicit `walletAddress` - neither throws `"bootstrapMerchant: must provide either generated wallets or an explicit walletAddress"`. The function opens a DB connection via `createDb` and always `close()`s it in a `finally`, so you don't manage the pool. The returned `apiKey.rawKey` is shown **once** - surface it immediately; it isn't recoverable.
+You must supply **either** generated `wallets` **or** an explicit `walletAddress`; supplying neither throws `"bootstrapMerchant: must provide either generated wallets or an explicit walletAddress"`. The function opens a DB connection via `createDb` and always `close()`s it in a `finally`, so you don't manage the pool. The returned `apiKey.rawKey` is shown **once**, so surface it immediately; it isn't recoverable.
 
-## `createApiKey(options)` - mint a key for an existing merchant
+## `createApiKey(options)`: mint a key for an existing merchant
 
 ```ts
 import { createApiKey } from "@pincerpay/onboarding";
@@ -70,16 +70,16 @@ const key = await createApiKey({
 // → { rawKey, prefix, label, merchantId, merchantName, environment }
 ```
 
-`merchant` is resolved as a UUID first, then by case-insensitive name. Ambiguity and misses throw clear errors: `No merchant found with id ...`, `No merchant found with name "..."`, or `Name "..." matched multiple merchants. Pass --merchant <id> instead.` A **test** key cannot settle on a mainnet chain - mint `live` for production traffic. Like bootstrap, this hashes the key through the shared `@pincerpay/db` helpers, so set `TOKEN_PEPPER` in the environment to get HMAC-hashed keys (see the [Database & key hashing guide](/docs/guide-db)).
+`merchant` is resolved as a UUID first, then by case-insensitive name. Ambiguity and misses throw clear errors: `No merchant found with id ...`, `No merchant found with name "..."`, or `Name "..." matched multiple merchants. Pass --merchant <id> instead.` A **test** key cannot settle on a mainnet chain, so mint `live` for production traffic. Like bootstrap, this hashes the key through the shared `@pincerpay/db` helpers, so set `TOKEN_PEPPER` in the environment to get HMAC-hashed keys (see the [Database & key hashing guide](/docs/guide-db)).
 
-## `listMerchantsAll(databaseUrl)` - admin lookup
+## `listMerchantsAll(databaseUrl)`: admin lookup
 
 ```ts
 const merchants = await listMerchantsAll(process.env.DATABASE_URL!);
 // → ListedMerchant[]  ({ id, name, authUserId }), ordered by createdAt
 ```
 
-A thin admin helper for resolving which merchant is which before minting keys. Opens and closes its own connection.
+A thin admin helper for resolving which merchant is which before minting keys. It opens and closes its own connection.
 
 ## Putting it together
 

--- a/apps/dashboard/content/docs/guide-onboarding.md
+++ b/apps/dashboard/content/docs/guide-onboarding.md
@@ -1,0 +1,95 @@
+---
+title: "Onboarding Functions"
+description: "Implementation guide to @pincerpay/onboarding — non-custodial wallet generation, one-call merchant bootstrap, and API key minting against your own database."
+order: 3.9
+section: SDK Guides
+---
+
+`@pincerpay/onboarding` is the programmatic version of what the `pincerpay` CLI does: generate non-custodial wallets, create a merchant row, and mint an API key — all against a database you control. It's for building your own signup flow or admin tooling. This guide covers each exported function and the non-custodial contract you're responsible for upholding.
+
+> **ESM-only.** The wallet generator runs anywhere Node crypto does; the merchant/key functions are **server-side** and open a Postgres connection. Three entry points: `@pincerpay/onboarding` (everything), `@pincerpay/onboarding/wallets`, and `@pincerpay/onboarding/merchant`.
+
+## `generateMerchantWallets(options?)` — local, non-custodial keys
+
+```ts
+import { generateMerchantWallets } from "@pincerpay/onboarding";
+
+const wallets = await generateMerchantWallets();       // 12-word mnemonic (strength: 128)
+const big = await generateMerchantWallets({ strength: 256 }); // 24 words
+const restored = await generateMerchantWallets({ mnemonic }); // re-derive from an existing phrase
+```
+
+Returns a `MerchantWallets`:
+
+```ts
+interface MerchantWallets {
+  mnemonic: string;                 // BIP-39 phrase
+  solana: ChainWallet;              // { address, privateKey (bs58), derivationPath }
+  evm: ChainWallet;                 // { address, privateKey (0x-hex), derivationPath }
+}
+```
+
+It derives a Solana key at `m/44'/501'/0'/0'` (Phantom-compatible) and an EVM key at `m/44'/60'/0'/0/0` (MetaMask-compatible) — both exported as `SOLANA_DERIVATION_PATH` / `EVM_DERIVATION_PATH`. A supplied `mnemonic` must be valid BIP-39 or it throws `"Invalid BIP-39 mnemonic"`; a degenerate EVM derivation throws `"EVM derivation produced no private key"`.
+
+> **Non-custodial contract.** This function returns the mnemonic and private keys to *you* and PincerPay never sees them. That's the whole point — and the responsibility. Display them once to the merchant, let them save the phrase, and discard from memory. Don't log them, don't persist them server-side. Only public addresses should ever leave the process.
+
+## `bootstrapMerchant(options)` — zero to merchant in one call
+
+The end-to-end path: take (or generate) wallets, insert the merchant, mint a live API key, return env-ready output.
+
+```ts
+import { generateMerchantWallets, bootstrapMerchant } from "@pincerpay/onboarding";
+
+const wallets = await generateMerchantWallets();
+const result = await bootstrapMerchant({
+  databaseUrl: process.env.DATABASE_URL!,
+  name: "Acme Co",
+  authUserId: supabaseUserId,
+  wallets,
+  supportedChains: ["solana", "polygon"],
+  webhookUrlLive: "https://acme.example/webhooks",
+});
+// result: { merchantId, walletsGenerated, wallets?, apiKey: { rawKey, prefix, label }, webhookSecret }
+```
+
+Defaults worth knowing: `walletAddress` falls back to `wallets.solana.address`; `walletAddresses` defaults to `{ solana, evm }`; `supportedChains` defaults to `["solana", "polygon"]` when wallets are present (else `[]`); `apiKeyLabel` defaults to `"Bootstrap"`. The API key is always minted in the **`live`** environment. A live webhook secret (random 32-byte hex) is always generated; a test secret only if you pass `webhookUrlTest`.
+
+You must supply **either** generated `wallets` **or** an explicit `walletAddress` — neither throws `"bootstrapMerchant: must provide either generated wallets or an explicit walletAddress"`. The function opens a DB connection via `createDb` and always `close()`s it in a `finally`, so you don't manage the pool. The returned `apiKey.rawKey` is shown **once** — surface it immediately; it isn't recoverable.
+
+## `createApiKey(options)` — mint a key for an existing merchant
+
+```ts
+import { createApiKey } from "@pincerpay/onboarding";
+
+const key = await createApiKey({
+  databaseUrl: process.env.DATABASE_URL!,
+  merchant: "Acme Co",        // UUID, or case-insensitive name
+  label: "production",        // default "CLI"
+  environment: "live",        // default "live"; "test" | "live"
+});
+// → { rawKey, prefix, label, merchantId, merchantName, environment }
+```
+
+`merchant` is resolved as a UUID first, then by case-insensitive name. Ambiguity and misses throw clear errors: `No merchant found with id ...`, `No merchant found with name "..."`, or `Name "..." matched multiple merchants. Pass --merchant <id> instead.` A **test** key cannot settle on a mainnet chain — mint `live` for production traffic. Like bootstrap, this hashes the key through the shared `@pincerpay/db` helpers, so set `TOKEN_PEPPER` in the environment to get HMAC-hashed keys (see the [Database & key hashing guide](/docs/guide-db)).
+
+## `listMerchantsAll(databaseUrl)` — admin lookup
+
+```ts
+const merchants = await listMerchantsAll(process.env.DATABASE_URL!);
+// → ListedMerchant[]  ({ id, name, authUserId }), ordered by createdAt
+```
+
+A thin admin helper for resolving which merchant is which before minting keys. Opens and closes its own connection.
+
+## Putting it together
+
+```ts
+const wallets = await generateMerchantWallets();
+// → show wallets.mnemonic to the merchant, have them confirm they saved it
+const { merchantId, apiKey } = await bootstrapMerchant({
+  databaseUrl, name, authUserId, wallets, supportedChains: ["solana"],
+});
+console.log("Save this key now, it won't be shown again:", apiKey.rawKey);
+```
+
+> **Heads-up on key hashing:** because these functions mint keys, the runtime that calls them must share the **same `TOKEN_PEPPER`** as the facilitator, or the keys won't authenticate. With no pepper set they fall back to legacy SHA-256 (still usable). Details in the [Database & key hashing guide](/docs/guide-db).

--- a/apps/dashboard/content/docs/guide-onboarding.md
+++ b/apps/dashboard/content/docs/guide-onboarding.md
@@ -1,15 +1,15 @@
 ---
 title: "Onboarding Functions"
-description: "Implementation guide to @pincerpay/onboarding — non-custodial wallet generation, one-call merchant bootstrap, and API key minting against your own database."
+description: "Implementation guide to @pincerpay/onboarding - non-custodial wallet generation, one-call merchant bootstrap, and API key minting against your own database."
 order: 3.9
 section: SDK Guides
 ---
 
-`@pincerpay/onboarding` is the programmatic version of what the `pincerpay` CLI does: generate non-custodial wallets, create a merchant row, and mint an API key — all against a database you control. It's for building your own signup flow or admin tooling. This guide covers each exported function and the non-custodial contract you're responsible for upholding.
+`@pincerpay/onboarding` is the programmatic version of what the `pincerpay` CLI does: generate non-custodial wallets, create a merchant row, and mint an API key - all against a database you control. It's for building your own signup flow or admin tooling. This guide covers each exported function and the non-custodial contract you're responsible for upholding.
 
 > **ESM-only.** The wallet generator runs anywhere Node crypto does; the merchant/key functions are **server-side** and open a Postgres connection. Three entry points: `@pincerpay/onboarding` (everything), `@pincerpay/onboarding/wallets`, and `@pincerpay/onboarding/merchant`.
 
-## `generateMerchantWallets(options?)` — local, non-custodial keys
+## `generateMerchantWallets(options?)` - local, non-custodial keys
 
 ```ts
 import { generateMerchantWallets } from "@pincerpay/onboarding";
@@ -29,11 +29,11 @@ interface MerchantWallets {
 }
 ```
 
-It derives a Solana key at `m/44'/501'/0'/0'` (Phantom-compatible) and an EVM key at `m/44'/60'/0'/0/0` (MetaMask-compatible) — both exported as `SOLANA_DERIVATION_PATH` / `EVM_DERIVATION_PATH`. A supplied `mnemonic` must be valid BIP-39 or it throws `"Invalid BIP-39 mnemonic"`; a degenerate EVM derivation throws `"EVM derivation produced no private key"`.
+It derives a Solana key at `m/44'/501'/0'/0'` (Phantom-compatible) and an EVM key at `m/44'/60'/0'/0/0` (MetaMask-compatible) - both exported as `SOLANA_DERIVATION_PATH` / `EVM_DERIVATION_PATH`. A supplied `mnemonic` must be valid BIP-39 or it throws `"Invalid BIP-39 mnemonic"`; a degenerate EVM derivation throws `"EVM derivation produced no private key"`.
 
-> **Non-custodial contract.** This function returns the mnemonic and private keys to *you* and PincerPay never sees them. That's the whole point — and the responsibility. Display them once to the merchant, let them save the phrase, and discard from memory. Don't log them, don't persist them server-side. Only public addresses should ever leave the process.
+> **Non-custodial contract.** This function returns the mnemonic and private keys to *you* and PincerPay never sees them. That's the whole point - and the responsibility. Display them once to the merchant, let them save the phrase, and discard from memory. Don't log them, don't persist them server-side. Only public addresses should ever leave the process.
 
-## `bootstrapMerchant(options)` — zero to merchant in one call
+## `bootstrapMerchant(options)` - zero to merchant in one call
 
 The end-to-end path: take (or generate) wallets, insert the merchant, mint a live API key, return env-ready output.
 
@@ -54,9 +54,9 @@ const result = await bootstrapMerchant({
 
 Defaults worth knowing: `walletAddress` falls back to `wallets.solana.address`; `walletAddresses` defaults to `{ solana, evm }`; `supportedChains` defaults to `["solana", "polygon"]` when wallets are present (else `[]`); `apiKeyLabel` defaults to `"Bootstrap"`. The API key is always minted in the **`live`** environment. A live webhook secret (random 32-byte hex) is always generated; a test secret only if you pass `webhookUrlTest`.
 
-You must supply **either** generated `wallets` **or** an explicit `walletAddress` — neither throws `"bootstrapMerchant: must provide either generated wallets or an explicit walletAddress"`. The function opens a DB connection via `createDb` and always `close()`s it in a `finally`, so you don't manage the pool. The returned `apiKey.rawKey` is shown **once** — surface it immediately; it isn't recoverable.
+You must supply **either** generated `wallets` **or** an explicit `walletAddress` - neither throws `"bootstrapMerchant: must provide either generated wallets or an explicit walletAddress"`. The function opens a DB connection via `createDb` and always `close()`s it in a `finally`, so you don't manage the pool. The returned `apiKey.rawKey` is shown **once** - surface it immediately; it isn't recoverable.
 
-## `createApiKey(options)` — mint a key for an existing merchant
+## `createApiKey(options)` - mint a key for an existing merchant
 
 ```ts
 import { createApiKey } from "@pincerpay/onboarding";
@@ -70,9 +70,9 @@ const key = await createApiKey({
 // → { rawKey, prefix, label, merchantId, merchantName, environment }
 ```
 
-`merchant` is resolved as a UUID first, then by case-insensitive name. Ambiguity and misses throw clear errors: `No merchant found with id ...`, `No merchant found with name "..."`, or `Name "..." matched multiple merchants. Pass --merchant <id> instead.` A **test** key cannot settle on a mainnet chain — mint `live` for production traffic. Like bootstrap, this hashes the key through the shared `@pincerpay/db` helpers, so set `TOKEN_PEPPER` in the environment to get HMAC-hashed keys (see the [Database & key hashing guide](/docs/guide-db)).
+`merchant` is resolved as a UUID first, then by case-insensitive name. Ambiguity and misses throw clear errors: `No merchant found with id ...`, `No merchant found with name "..."`, or `Name "..." matched multiple merchants. Pass --merchant <id> instead.` A **test** key cannot settle on a mainnet chain - mint `live` for production traffic. Like bootstrap, this hashes the key through the shared `@pincerpay/db` helpers, so set `TOKEN_PEPPER` in the environment to get HMAC-hashed keys (see the [Database & key hashing guide](/docs/guide-db)).
 
-## `listMerchantsAll(databaseUrl)` — admin lookup
+## `listMerchantsAll(databaseUrl)` - admin lookup
 
 ```ts
 const merchants = await listMerchantsAll(process.env.DATABASE_URL!);


### PR DESCRIPTION
## Summary

Adds a new **"SDK Guides"** docs-site section: narrative, function-by-function implementation guides for the **entire public SDK surface**, written as developer walkthroughs rather than terse reference. Five flat pages in `apps/dashboard/content/docs/` (`section: "SDK Guides"`, order `3.6`–`3.95`, rendering between the SDKs and Learn sections):

- **`guide-core`** — `resolveChain` (returns `undefined`) vs `toCAIP2` (throws), the address validators, `resolveMerchantAddress` precedence, the Zod config schemas, and the base-units-vs-human-decimals rule that causes most integration bugs.
- **`guide-agent`** — `PincerPayAgent`: why `create()` (not `new`) is required for Solana, how `fetch()` transparently handles `402`, and the key caveat that `checkPolicy` enforces only the amount limits (not `allowedMerchants`/`allowedChains`), with UTC-daily/in-memory tracking.
- **`guide-merchant`** — `createPincerPayMiddleware` config (incl. the no-op `syncFacilitatorOnStart` and `solana` default chain), its eager startup validation, the 402 lifecycle, `PincerPayClient`, and `toBaseUnits`/`resolveRouteChains`/`getUsdcAsset`.
- **`guide-onboarding`** — `generateMerchantWallets` (non-custodial contract), `bootstrapMerchant`, `createApiKey`, `listMerchantsAll`.
- **`guide-db`** — `createDb` (`:6543` pooler detection, `close()`), the api-key hashing helpers, and the cross-service `TOKEN_PEPPER` contract; cross-links the cleanup script.

## Accuracy
Every signature, default, and failure mode was verified verbatim against source (not approximated). Notable real gotchas are called out explicitly (the `create()`-vs-`new` Solana trap, `checkPolicy` scope, base-units, eager middleware validation, pooler ports). All internal `/docs/*` links resolve.

## Test plan
- [x] Frontmatter parses; the five pages sort correctly into the new section.
- [x] All internal links resolve to existing doc slugs.
- [x] Content-only (no code paths); CI build will compile the markdown.

https://claude.ai/code/session_01KJhKgoX3z3UU5e8iknFTzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJhKgoX3z3UU5e8iknFTzX)_