### PR TITLE
docs: stabilize consumer-facing contracts from Fools integration feedback

### DIFF
--- a/.changeset/fools-integration-feedback.md
+++ b/.changeset/fools-integration-feedback.md
@@ -1,0 +1,24 @@
+---
+"@pincerpay/merchant": minor
+"@pincerpay/mcp": minor
+"@pincerpay/core": patch
+"@pincerpay/agent": patch
+---
+
+Stabilize consumer-facing contracts based on integration feedback.
+
+`@pincerpay/merchant` now re-exports the middleware context contract
+(`PincerPayContextVariables`, `PincerPayPaymentInfo`) from the package root, not
+just from `@pincerpay/merchant/nextjs`. The middleware sets exactly one Hono
+context key, `pincerpay`; import the type instead of duck-typing the shape and
+any future change is a compile error. (There is no `agentWallet` context key.)
+
+`@pincerpay/mcp` tools now carry MCP `ToolAnnotations`
+(`readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`), and the
+irreversible `delete-paywall` tool requires `confirm: true` before it will run.
+
+Docs: added `RELEASING.md` (version-coupling contract - these packages release as
+one linked set and `merchant` pins `core` exact), per-package `CHANGELOG.md`
+files (previously gitignored and missing from npm), a canonical x402 OpenAPI
+security-scheme snippet, a test-vs-live API key reference, and MCP authoring
+conventions.

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ Thumbs.db
 _planning/
 CLAUDE.md
 STATUS.md
-CHANGELOG.md
 TESTS.md
 
 # Admin dashboard (private — deploy via local `vercel --prod`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,10 @@ examples/
 
 1. Fork the repo and create a branch: `feat/description`, `fix/description`, or `chore/description`
 2. Make your changes
-3. Run `pnpm typecheck && pnpm test && pnpm build` to verify
-4. Commit using conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`
-5. Open a pull request against `master`
+3. Add a changeset (`pnpm changeset`) describing any consumer-facing change to a published package (`core`, `agent`, `merchant`, `mcp`). These four release as one linked set - see [RELEASING.md](RELEASING.md).
+4. Run `pnpm typecheck && pnpm test && pnpm build` to verify
+5. Commit using conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`
+6. Open a pull request against `master`
 
 ## Conventions
 
@@ -79,6 +80,13 @@ Larger contributions (please open an issue first):
 - New chain support
 - Protocol integrations
 - SDK features
+
+## Releasing
+
+`core`, `agent`, `merchant`, and `mcp` publish to npm as one linked set and
+always share a version (`merchant` pins `core` exact). See
+[RELEASING.md](RELEASING.md) for the coupling contract, the changeset-driven
+publish flow, and how to cut a `next` dist-tag prerelease.
 
 ## Questions?
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,90 @@
+# Releasing PincerPay packages
+
+This repo publishes four public packages to npm. They are released together as a
+single **linked set** and always share the same version number:
+
+- [`@pincerpay/core`](packages/core) - shared types, chain configs, constants
+- [`@pincerpay/agent`](packages/agent) - agent-side `fetch` wrapper
+- [`@pincerpay/merchant`](packages/merchant) - merchant middleware
+- [`@pincerpay/mcp`](packages/mcp) - MCP server
+
+## Version-coupling contract
+
+**Bump them together.** The `.changeset/config.json` `linked` group ties
+`core`, `agent`, `merchant`, and `mcp` to one version. A changeset that touches
+any one of them moves all four to the same new version, even if a package had no
+functional change. (That is why, e.g., `merchant` and `mcp` 0.9.0 were
+package.json-only bumps.)
+
+**`merchant` pins `core` exact.** In the published manifests the workspace
+protocol resolves `@pincerpay/core` to the **exact** current version (not `^`).
+So installing a given `@pincerpay/merchant` always pulls the matching `core`.
+Treat `core` + `agent` + `merchant` (+ `mcp`) as one unit when upgrading.
+
+**Internal dependency bumps are `minor`.** `updateInternalDependencies: "minor"`
+means a consumer-visible bump to one package propagates as at least a minor bump.
+
+**Versions can be skipped.** `0.7.0` was never published; the line went
+`0.6.0 → 0.8.0 → 0.9.0`. Don't assume contiguous versions.
+
+### Compatibility matrix
+
+| If you install | You also get (matching) |
+|----------------|-------------------------|
+| `@pincerpay/merchant@X` | `@pincerpay/core@X` (exact pin) |
+| `@pincerpay/agent@X`    | `@pincerpay/core@X`             |
+| `@pincerpay/mcp@X`      | `@pincerpay/core@X`             |
+
+Always install the four at the same `X`.
+
+## Per-package changelogs
+
+Each package ships a `CHANGELOG.md` (listed in its `files` array, so it lands on
+npm). `changeset version` appends to these automatically from the changeset
+markdown files. **Do not gitignore `CHANGELOG.md`** - earlier it was ignored,
+which is why no consumer-facing summary shipped through several releases.
+
+When you change the `merchant` middleware context contract, the `agent` `.fetch`
+surface, or any exported type in `core`, say so in a changeset so it reaches the
+changelog.
+
+## Cutting a release (GA)
+
+Releases run from CI (`.github/workflows/publish.yml`) via
+[`changesets/action`](https://github.com/changesets/action):
+
+1. Land PRs that each include a changeset (`pnpm changeset`).
+2. The action opens/maintains a **"chore: version packages"** PR that applies the
+   version bumps and updates the changelogs.
+3. Merging that PR to `master` triggers `pnpm release`
+   (`build && test && changeset publish`), which publishes to npm under the
+   `latest` dist-tag and pushes git tags.
+
+> If `master` shows a bumped version but npm and git tags do not, the publish
+> step failed (commonly a failed `build`/`test` or a missing/expired `NPM_TOKEN`
+> secret). Re-run the Release workflow after fixing the underlying cause.
+
+## Cutting a prerelease (`next` dist-tag)
+
+To let downstream consumers validate a build ahead of GA, publish the current
+versions to the npm `next` dist-tag without changing version numbers or the
+`latest` tag:
+
+```bash
+pnpm release:next
+```
+
+This runs `build && test` and then `changeset publish --tag next`. Consumers
+install with `npm install @pincerpay/merchant@next` (and the matching
+`core`/`agent`/`mcp@next`). When the build is validated, promote it to `latest`:
+
+```bash
+npm dist-tag add @pincerpay/core@<version> latest
+npm dist-tag add @pincerpay/agent@<version> latest
+npm dist-tag add @pincerpay/merchant@<version> latest
+npm dist-tag add @pincerpay/mcp@<version> latest
+```
+
+Requires an npm token with publish rights for the `@pincerpay` scope
+(`NODE_AUTH_TOKEN` / `npm login`). Publishing and tagging are **manual,
+owner-run** steps; CI only publishes `latest` on merge of the version PR.

--- a/apps/dashboard/content/docs/api-reference.md
+++ b/apps/dashboard/content/docs/api-reference.md
@@ -21,6 +21,22 @@ Create API keys from the [dashboard](https://www.pincerpay.com/dashboard). Keys 
 
 Public endpoints (`/v1/supported`, `/health`, `/metrics`, `/openapi.json`) do not require authentication.
 
+### Test vs live keys
+
+Test/live key separation is **shipped**. Every API key carries an environment that
+determines which rails it can use:
+
+| Prefix | Environment | Settles on | Webhooks | Mint with |
+|--------|-------------|------------|----------|-----------|
+| `pp_live_` | `live` | Mainnet chains (`solana`, `base`, `polygon`) | Live-mode webhook URL | dashboard, or `pincerpay create-api-key` |
+| `pp_test_` | `test` | Testnet/devnet chains only (`solana-devnet`, `base-sepolia`, ... - any chain where `ChainConfig.testnet === true`) | Test-mode webhook URL only | dashboard, or `pincerpay create-api-key --test` |
+
+A **test key cannot settle on a mainnet chain** (the facilitator rejects it), and a
+live key is meant for real-money mainnet traffic. Test transactions never trigger
+production webhooks. There is no single key that maps to both; pick the key for the
+rail you are targeting. Mainnet vs devnet is otherwise selected per route/payment
+by the `network` (CAIP-2) you advertise.
+
 ## POST /v1/verify
 
 Verify a signed payment transaction without broadcasting it. Returns whether the payment is valid and the payer address.

--- a/apps/dashboard/content/docs/mcp-server.md
+++ b/apps/dashboard/content/docs/mcp-server.md
@@ -191,6 +191,49 @@ Interactive prompts guide your assistant through common workflows:
 | `manage-paywalls` | Paywall management: list, create, update, delete, or review configuration |
 | `monitor-payments` | Payment monitoring: overview, failure investigation, pending transaction analysis |
 
+## Conventions (for building your own MCP server)
+
+If you're modeling another MCP server on `@pincerpay/mcp`, these are the
+conventions it follows so downstream servers can inherit the same safety bar:
+
+- **Server factory.** Build the server with the exported factory rather than
+  re-wiring it: `import { createPincerPayMcpServer } from "@pincerpay/mcp/server"`.
+  It registers all tools, resources, and prompts and accepts `{ apiKey?, facilitatorUrl? }`.
+- **Tool naming.** Lowercase kebab-case, `verb-noun` (`create-paywall`,
+  `check-transaction-status`, `estimate-gas-cost`). Read tools start with
+  `list-`/`get-`/`check-`; generators start with `scaffold-`/`generate-`.
+- **Safety annotations.** Every tool carries MCP
+  [`ToolAnnotations`](https://modelcontextprotocol.io). Read-only tools set
+  `readOnlyHint: true`; tools that hit the facilitator set `openWorldHint: true`;
+  mutating tools set `readOnlyHint: false` with an explicit `idempotentHint`, and
+  the one irreversible tool (`delete-paywall`) sets `destructiveHint: true`.
+- **Confirm on destructive actions.** `delete-paywall` takes `confirm: boolean`
+  and refuses to run unless `confirm: true`, pointing the caller at the
+  non-destructive alternative (`update-paywall` with `isActive=false`). Apply the
+  same `confirm` gate to any tool that spends funds or destroys data.
+- **Dry-run first.** `verify-payment` validates a payment against the facilitator
+  **without broadcasting** - the dry-run/"paper" path before anything settles on
+  chain.
+- **Cost estimate.** `estimate-gas-cost` returns per-chain fee estimates so an
+  agent can price an action before committing.
+- **Auth is per-call and degrades gracefully.** Tools call `client.requireAuth()`
+  and return a helpful, non-throwing error when no key is configured, so the
+  no-auth tools (scaffolding, chain listing, health) still work.
+- **Base units gotcha.** Route `price` is human-readable USDC (`"0.01"`), but
+  spending policies use base units with 6 decimals (`"10000"` = $0.01). Surface
+  this in tool descriptions to prevent `BigInt()` throwing at runtime.
+- **`bin` convention.** The package ships a `pincerpay-mcp` bin (`dist/cli.js`)
+  and an `mcpName` field, so it runs via `npx @pincerpay/mcp` over stdio or
+  `--transport=http`.
+
+**Not yet provided (don't assume these exist):** there is no exported
+spend-limit guard helper and no per-agent/per-session spend-cap enforcement baked
+into the server - spend limits live in agent-side `SpendingPolicy` (base units)
+and the dashboard, not as an MCP middleware. If you need a reusable guard, build
+it in your own server for now; a shared helper is a candidate for a future
+release. The PincerPay MCP server itself does not expose a money-spending tool,
+so the `confirm: true` convention currently applies to `delete-paywall`.
+
 ## Try It
 
 After connecting, paste any of these into your AI assistant:

--- a/apps/dashboard/content/docs/merchant-sdk.md
+++ b/apps/dashboard/content/docs/merchant-sdk.md
@@ -148,6 +148,8 @@ app.post("/api/trade", async (c) => {
 
 The same `payer` field is also included in the base64-encoded `payment-response` response header for clients that bypass the middleware.
 
+The middleware sets **exactly one** context variable, `pincerpay` (typed as `PincerPayPaymentInfo`). There is no `agentWallet` context key: in the example above, `agentWallet` is just a field name on the caller's own `recordTrade(...)` function. Import `PincerPayContextVariables` / `PincerPayPaymentInfo` from `@pincerpay/merchant` (or `@pincerpay/merchant/nextjs`) instead of duck-typing the shape, so you fail at compile time if the contract changes. Any change to the keys set, or to `PincerPayPaymentInfo`, is called out in the merchant package CHANGELOG.
+
 ## Configuration
 
 `createPincerPayMiddleware()` accepts a `PincerPayConfig` object:

--- a/apps/dashboard/content/docs/x402.md
+++ b/apps/dashboard/content/docs/x402.md
@@ -54,3 +54,66 @@ The PincerPay Facilitator is the intermediary that verifies and broadcasts trans
 3. **Confirm** -- monitors confirmation status and notifies merchants via webhooks
 
 Merchants interact with the facilitator through the [`@pincerpay/merchant` middleware](/docs/merchant-sdk). Agents interact through [`@pincerpay/agent`](/docs/agent-sdk). Neither needs direct facilitator API knowledge for basic usage. See the [API Reference](/docs/api-reference) for direct integration.
+
+## Describing x402 in OpenAPI
+
+If you publish an OpenAPI spec for an x402-paywalled API, model the payment receipt as an `apiKey` security scheme carried in the `X-PAYMENT` request header. This is the canonical representation; every downstream spec should describe it the same way so tools and agents recognize it.
+
+The exact wire contract set by the PincerPay middleware:
+
+- **Payment receipt header (request):** `X-PAYMENT` (the middleware also accepts `payment-signature` for compatibility, but `X-PAYMENT` is canonical).
+- **Unpaid response:** HTTP `402` with the requirements JSON in the body and a base64-encoded copy in the `payment-required` response header.
+- **Settled response:** the original `2xx`, plus a base64-encoded receipt in the `payment-response` response header.
+- **Price:** advertised in the 402 body at `accepts[].amount`, as **USDC base units** (6 decimals - `"10000"` = $0.01), per `scheme`/`network`/`asset`/`payTo`. There is no `X-PRICE-USD` header; price is not a header at all.
+
+```yaml
+components:
+  securitySchemes:
+    x402Payment:
+      type: apiKey
+      in: header
+      name: X-PAYMENT
+      description: >
+        Base64-encoded x402 payment payload. Obtain the requirements by
+        calling the endpoint without this header and reading the 402 response
+        body (`accepts[]`), then settle and retry with the receipt here.
+  responses:
+    PaymentRequired:
+      description: Payment required (x402). Body lists accepted payment options.
+      headers:
+        payment-required:
+          schema: { type: string }
+          description: Base64-encoded copy of the requirements body.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              x402Version: { type: integer, example: 2 }
+              accepts:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    scheme:  { type: string, example: exact }
+                    network: { type: string, example: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1" }
+                    amount:  { type: string, description: "USDC base units (6 decimals)", example: "10000" }
+                    asset:   { type: string, description: "USDC token address on the network" }
+                    payTo:   { type: string }
+
+paths:
+  /api/data:
+    get:
+      security:
+        - x402Payment: []
+      # Recommended vendor extension for static price advertisement.
+      # The authoritative price is always the live 402 `accepts[].amount`.
+      x-pincerpay-price:
+        usdc: "0.01"          # human-readable USDC
+        chains: ["solana"]    # chain shorthands that can settle
+      responses:
+        "200": { description: Resource delivered after payment }
+        "402": { $ref: "#/components/responses/PaymentRequired" }
+```
+
+> Prefer `x-pincerpay-price` (human-readable USDC + chains, mirroring `PincerPayConfig["routes"]`) over an ad-hoc `x-price-usd`, and treat it as advisory: the live 402 `accepts[].amount` (base units) is the source of truth.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "bootstrap-merchant": "tsx scripts/bootstrap-merchant.mts",
     "changeset": "changeset",
     "version-packages": "changeset version && node scripts/sync-plugin-version.mjs",
-    "release": "pnpm build && pnpm test && changeset publish"
+    "release": "pnpm build && pnpm test && changeset publish",
+    "release:next": "pnpm build && pnpm test && changeset publish --tag next"
   },
   "pnpm": {
     "overrides": {

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,0 +1,18 @@
+# @pincerpay/agent
+
+> **Version coupling.** `@pincerpay/core`, `@pincerpay/agent`, `@pincerpay/merchant`,
+> and `@pincerpay/mcp` are released as one linked set and always share the same
+> version number - upgrade them together. `@pincerpay/agent` depends on a matching
+> `@pincerpay/core`. See [RELEASING.md](../../RELEASING.md) for the full contract.
+
+## 0.9.0
+
+### Patch Changes
+
+- README no longer documents the removed `SolanaSmartAgent` class, its methods,
+  or its config. The documented surface now matches what actually ships
+  (`PincerPayAgent`). The `.fetch`-only wrapper surface is unchanged.
+
+> Released in lockstep with `@pincerpay/core`, `@pincerpay/merchant`, and
+> `@pincerpay/mcp` 0.9.0. (Version 0.7.0 was skipped; the previous release was
+> 0.8.0.)

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -39,6 +39,7 @@
   "files": [
     "dist",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "main": "dist/index.js",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,20 @@
+# @pincerpay/core
+
+> **Version coupling.** `@pincerpay/core`, `@pincerpay/agent`, `@pincerpay/merchant`,
+> and `@pincerpay/mcp` are released as one linked set and always share the same
+> version number - upgrade them together. `@pincerpay/merchant` pins
+> `@pincerpay/core` to an **exact** version. See [RELEASING.md](../../RELEASING.md)
+> for the full contract.
+
+## 0.9.0
+
+### Minor Changes
+
+- Remove the orphaned `SolanaSmartAgentConfig` type export. `SolanaSmartAgent`
+  and its implementation were removed from the agent SDK during the slim launch,
+  but a dangling type was left behind in core. The published type surface now
+  matches what actually ships (`PincerPayAgent`).
+
+> Released in lockstep with `@pincerpay/agent`, `@pincerpay/merchant`, and
+> `@pincerpay/mcp` 0.9.0. (Version 0.7.0 was skipped; the previous release was
+> 0.8.0.)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
   "files": [
     "dist",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "main": "dist/index.js",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,0 +1,17 @@
+# @pincerpay/mcp
+
+> **Version coupling.** `@pincerpay/core`, `@pincerpay/agent`, `@pincerpay/merchant`,
+> and `@pincerpay/mcp` are released as one linked set and always share the same
+> version number - upgrade them together. See [RELEASING.md](../../RELEASING.md)
+> for the full contract.
+
+## 0.9.0
+
+### Patch Changes
+
+- Released in lockstep with `@pincerpay/core` 0.9.0. No changes to the tool,
+  resource, or prompt surface in this release.
+
+> Released in lockstep with `@pincerpay/core`, `@pincerpay/agent`, and
+> `@pincerpay/merchant` 0.9.0. (Version 0.7.0 was skipped; the previous release
+> was 0.8.0.)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -51,6 +51,7 @@
   "files": [
     "dist",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "mcpName": "pincerpay-mcp",

--- a/packages/mcp/src/tools/bootstrap-merchant.ts
+++ b/packages/mcp/src/tools/bootstrap-merchant.ts
@@ -37,6 +37,7 @@ export function registerBootstrapMerchant(server: McpServer) {
       "PincerPay never persists the mnemonic or private keys; the caller must display them once " +
       "and discard.",
     inputSchema,
+    { title: "Bootstrap merchant", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     async (args) => {
       const auth = resolveAuthMode();
 

--- a/packages/mcp/src/tools/bootstrap-wallets.ts
+++ b/packages/mcp/src/tools/bootstrap-wallets.ts
@@ -32,6 +32,7 @@ export function registerBootstrapWallets(server: McpServer) {
       "Use this before bootstrap-merchant to provision wallets, or independently to generate " +
       "any new keypair set.",
     inputSchema,
+    { title: "Bootstrap wallets", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
     async ({ strength, mnemonic, includePrivateKeys }) => {
       try {
         const wallets = await generateMerchantWallets({

--- a/packages/mcp/src/tools/check-health.ts
+++ b/packages/mcp/src/tools/check-health.ts
@@ -11,6 +11,7 @@ export function registerCheckHealth(
       "Returns database status, worker health, uptime, and Kora (gasless) status. " +
       "No API key required. Use this as the first troubleshooting step.",
     {},
+    { title: "Check facilitator health", readOnlyHint: true, openWorldHint: true },
     async () => {
       try {
         const result = await client.getHealth();

--- a/packages/mcp/src/tools/check-transaction.ts
+++ b/packages/mcp/src/tools/check-transaction.ts
@@ -21,6 +21,7 @@ export function registerCheckTransaction(
       "Returns chain, amount, addresses, status (pending/mempool/optimistic/confirmed/failed), " +
       "and timestamps. Requires a PincerPay API key.",
     inputSchema,
+    { title: "Check transaction status", readOnlyHint: true, openWorldHint: true },
     async ({ txHash }) => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/create-api-key.ts
+++ b/packages/mcp/src/tools/create-api-key.ts
@@ -22,6 +22,7 @@ export function registerCreateApiKey(server: McpServer) {
       "Auth modes: (1) admin if DATABASE_URL is set, requires --merchant; (2) public if " +
       "~/.pincerpay/credentials.json exists, mints for the logged-in user's merchant.",
     createSchema,
+    { title: "Create API key", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     async ({ merchant, label }) => {
       const auth = resolveAuthMode();
 
@@ -116,6 +117,7 @@ export function registerListMerchants(server: McpServer) {
     "Admin mode (DATABASE_URL): lists all merchants in the database. " +
       "Public mode (CLI credentials): returns only the caller's own merchant.",
     {},
+    { title: "List merchants", readOnlyHint: true, openWorldHint: true },
     async () => {
       const auth = resolveAuthMode();
 

--- a/packages/mcp/src/tools/create-paywall.ts
+++ b/packages/mcp/src/tools/create-paywall.ts
@@ -30,6 +30,7 @@ export function registerCreatePaywall(
     "Create a new paywalled endpoint. Sets the USDC price and optional chain restrictions. " +
       "The endpoint pattern must be unique per merchant. Requires a PincerPay API key.",
     inputSchema,
+    { title: "Create paywall", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     async ({ endpointPattern, amount, description, chains }) => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/delete-paywall.ts
+++ b/packages/mcp/src/tools/delete-paywall.ts
@@ -4,6 +4,13 @@ import type { FacilitatorClient } from "../client.js";
 
 const inputSchema = {
   id: z.string().uuid().describe("Paywall UUID to delete."),
+  confirm: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Must be set to true to actually delete. This is a destructive, " +
+        "irreversible operation; the tool refuses to run without explicit confirmation.",
+    ),
 };
 
 export function registerDeletePaywall(
@@ -14,14 +21,22 @@ export function registerDeletePaywall(
     "delete-paywall",
     "Permanently delete a paywalled endpoint. This cannot be undone. " +
       "Use update-paywall with isActive=false to disable without deleting. " +
-      "Requires a PincerPay API key.",
+      "Requires a PincerPay API key. Pass confirm=true to proceed.",
     inputSchema,
-    async ({ id }) => {
+    { title: "Delete paywall", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    async ({ id, confirm }) => {
       try {
         client.requireAuth();
       } catch (err) {
         return {
           content: [{ type: "text" as const, text: err instanceof Error ? err.message : String(err) }],
+          isError: true,
+        };
+      }
+
+      if (!confirm) {
+        return {
+          content: [{ type: "text" as const, text: `Refusing to delete paywall ${id}: this is irreversible. Re-run with confirm=true to proceed, or use update-paywall with isActive=false to disable it instead.` }],
           isError: true,
         };
       }

--- a/packages/mcp/src/tools/estimate-gas.ts
+++ b/packages/mcp/src/tools/estimate-gas.ts
@@ -59,6 +59,7 @@ export function registerEstimateGas(server: McpServer) {
       "Returns the native gas token, estimated USD cost, and notes about " +
       "Kora gasless transactions (Solana) or L2 gas optimization.",
     inputSchema,
+    { title: "Estimate gas cost", readOnlyHint: true, openWorldHint: false },
     async ({ chain, amount }) => {
       const chainConfig = resolveChain(chain);
       if (!chainConfig) {

--- a/packages/mcp/src/tools/generate-ucp.ts
+++ b/packages/mcp/src/tools/generate-ucp.ts
@@ -40,6 +40,7 @@ export function registerGenerateUcp(server: McpServer) {
       "payment requirements, supported chains, and endpoint pricing. " +
       "Place the output at /.well-known/ucp on your domain.",
     inputSchema,
+    { title: "Generate UCP manifest", readOnlyHint: true, openWorldHint: false },
     async ({ merchantName, merchantUrl, walletAddress, chains, endpoints }) => {
       const errors: string[] = [];
       const chainConfigs = chains.map((c) => {

--- a/packages/mcp/src/tools/get-merchant-profile.ts
+++ b/packages/mcp/src/tools/get-merchant-profile.ts
@@ -10,6 +10,7 @@ export function registerGetMerchantProfile(
     "Fetch your merchant profile including wallet address, supported chains, " +
       "webhook URL, and on-chain registration status. Requires a PincerPay API key.",
     {},
+    { title: "Get merchant profile", readOnlyHint: true, openWorldHint: true },
     async () => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/get-metrics.ts
+++ b/packages/mcp/src/tools/get-metrics.ts
@@ -11,6 +11,7 @@ export function registerGetMetrics(
       "Returns settlement counters, latency percentiles (p50/p95/p99), " +
       "verification stats, and error rates. No API key required.",
     {},
+    { title: "Get settlement metrics", readOnlyHint: true, openWorldHint: true },
     async () => {
       try {
         const result = await client.getMetrics();

--- a/packages/mcp/src/tools/list-agents.ts
+++ b/packages/mcp/src/tools/list-agents.ts
@@ -21,6 +21,7 @@ export function registerListAgents(
       "Shows Solana address, spending limits, Squads PDA, and status. " +
       "Agents are auto-registered on first payment. Requires a PincerPay API key.",
     inputSchema,
+    { title: "List agents", readOnlyHint: true, openWorldHint: true },
     async ({ limit, offset, status }) => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/list-chains.ts
+++ b/packages/mcp/src/tools/list-chains.ts
@@ -23,6 +23,7 @@ export function registerListChains(
       "Includes Solana (primary), Base, and Polygon with mainnet/testnet variants. " +
       "Shows chain shorthand, CAIP-2 ID, USDC contract address, and block time.",
     inputSchema,
+    { title: "List supported chains", readOnlyHint: true, openWorldHint: false },
     async ({ source }) => {
       if (source === "facilitator") {
         try {

--- a/packages/mcp/src/tools/list-paywalls.ts
+++ b/packages/mcp/src/tools/list-paywalls.ts
@@ -21,6 +21,7 @@ export function registerListPaywalls(
       "Returns endpoint patterns, USDC amounts, chain overrides, and active status. " +
       "Requires a PincerPay API key.",
     inputSchema,
+    { title: "List paywalls", readOnlyHint: true, openWorldHint: true },
     async ({ limit, offset, active }) => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/list-transactions.ts
+++ b/packages/mcp/src/tools/list-transactions.ts
@@ -37,6 +37,7 @@ export function registerListTransactions(
       "Returns chain, amount, status, gas costs, and timestamps. " +
       "Requires a PincerPay API key.",
     inputSchema,
+    { title: "List transactions", readOnlyHint: true, openWorldHint: true },
     async ({ limit, offset, status, chain, from, to, agent }) => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/list-webhooks.ts
+++ b/packages/mcp/src/tools/list-webhooks.ts
@@ -25,6 +25,7 @@ export function registerListWebhooks(
       "Shows event type, HTTP status code, retry count, and delivery status. " +
       "Useful for diagnosing missed webhook notifications. Requires a PincerPay API key.",
     inputSchema,
+    { title: "List webhooks", readOnlyHint: true, openWorldHint: true },
     async ({ limit, offset, status, event }) => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/login-instructions.ts
+++ b/packages/mcp/src/tools/login-instructions.ts
@@ -7,6 +7,7 @@ export function registerLoginInstructions(server: McpServer) {
     "Returns instructions for authenticating the MCP server. Call this when an onboarding " +
       "tool returns an auth error to guide the user through the right flow.",
     {},
+    { title: "Login instructions", readOnlyHint: true, openWorldHint: false },
     async () => {
       const auth = resolveAuthMode();
       const status = auth.mode;

--- a/packages/mcp/src/tools/retry-webhook.ts
+++ b/packages/mcp/src/tools/retry-webhook.ts
@@ -16,6 +16,7 @@ export function registerRetryWebhook(
       "Resets the delivery status and queues it for immediate retry. " +
       "Cannot retry already-delivered webhooks. Requires a PincerPay API key.",
     inputSchema,
+    { title: "Retry webhook delivery", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     async ({ id }) => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/scaffold-agent.ts
+++ b/packages/mcp/src/tools/scaffold-agent.ts
@@ -39,6 +39,7 @@ export function registerScaffoldAgent(server: McpServer) {
       "spending policies. The agent's fetch() is a drop-in replacement " +
       "for standard fetch that handles 402 challenges automatically.",
     inputSchema,
+    { title: "Scaffold agent client", readOnlyHint: true, openWorldHint: false },
     async ({ chain, maxPerTransaction, maxPerDay, typescript }) => {
       const isSolana = chain.startsWith("solana");
       const keyVar = isSolana ? "AGENT_SOLANA_KEY" : "AGENT_EVM_KEY";

--- a/packages/mcp/src/tools/scaffold-middleware.ts
+++ b/packages/mcp/src/tools/scaffold-middleware.ts
@@ -94,6 +94,7 @@ export function registerScaffoldMiddleware(server: McpServer) {
       "Supports Solana (primary), Base, and Polygon chains. " +
       "Pass `merchantAddresses` for multi-chain merchants, `merchantAddress` for single-chain.",
     inputSchema,
+    { title: "Scaffold merchant middleware", readOnlyHint: true, openWorldHint: false },
     async ({ routes, merchantAddress, merchantAddresses, typescript }) => {
       const bang = typescript ? "!" : "";
       const addressBlock = renderAddressBlock(

--- a/packages/mcp/src/tools/update-agent.ts
+++ b/packages/mcp/src/tools/update-agent.ts
@@ -32,6 +32,7 @@ export function registerUpdateAgent(
       "Set status to 'paused' or 'revoked' to block further payments. " +
       "Spending limits are in USDC base units (6 decimals). Requires a PincerPay API key.",
     inputSchema,
+    { title: "Update agent", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     async ({ id, name, status, maxPerTransaction, maxPerDay }) => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/update-paywall.ts
+++ b/packages/mcp/src/tools/update-paywall.ts
@@ -31,6 +31,7 @@ export function registerUpdatePaywall(
     "Update an existing paywall's price, description, chains, or active status. " +
       "Only provided fields are changed. Requires a PincerPay API key.",
     inputSchema,
+    { title: "Update paywall", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     async ({ id, amount, description, chains, isActive }) => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/validate-config.ts
+++ b/packages/mcp/src/tools/validate-config.ts
@@ -24,6 +24,7 @@ export function registerValidateConfig(server: McpServer) {
       "chain names, and USDC amounts. Returns validation results " +
       "with specific error messages for each issue found.",
     inputSchema,
+    { title: "Validate payment config", readOnlyHint: true, openWorldHint: false },
     async ({ config }) => {
       let parsed: unknown;
       try {

--- a/packages/mcp/src/tools/verify-payment.ts
+++ b/packages/mcp/src/tools/verify-payment.ts
@@ -27,6 +27,7 @@ export function registerVerifyPayment(
       "Checks signature validity, balance, and payment requirements. " +
       "Requires a PincerPay API key. Useful for debugging payment failures.",
     inputSchema,
+    { title: "Verify payment (dry-run)", readOnlyHint: true, openWorldHint: true },
     async ({ paymentPayload, paymentRequirements }) => {
       try {
         client.requireAuth();

--- a/packages/mcp/src/tools/whoami.ts
+++ b/packages/mcp/src/tools/whoami.ts
@@ -21,6 +21,7 @@ export function registerWhoami(server: McpServer) {
     "Returns information about the currently authenticated user — auth mode (admin vs public), " +
       "auth user id, session info, and current merchant. Useful diagnostic before mutating tools.",
     {},
+    { title: "Who am I", readOnlyHint: true, openWorldHint: true },
     async () => {
       const auth = resolveAuthMode();
 

--- a/packages/merchant/CHANGELOG.md
+++ b/packages/merchant/CHANGELOG.md
@@ -1,0 +1,31 @@
+# @pincerpay/merchant
+
+> **Version coupling.** `@pincerpay/core`, `@pincerpay/agent`, `@pincerpay/merchant`,
+> and `@pincerpay/mcp` are released as one linked set and always share the same
+> version number - upgrade them together. `@pincerpay/merchant` pins
+> `@pincerpay/core` to an **exact** version, so a `merchant` bump always implies a
+> matching `core` bump. See [RELEASING.md](../../RELEASING.md) for the full contract.
+
+## 0.9.0
+
+### Patch Changes
+
+- Released in lockstep with `@pincerpay/core` 0.9.0. No changes to the middleware
+  surface or the request-context contract.
+
+### Context contract
+
+The middleware sets exactly one Hono context variable, `pincerpay`, typed as
+`PincerPayPaymentInfo` (`{ payer, transaction, network }`). Import the typed
+shape so you fail at compile time if it ever changes:
+
+```ts
+import type { PincerPayContextVariables } from "@pincerpay/merchant";
+// or: from "@pincerpay/merchant/nextjs"
+
+const app = new Hono<{ Variables: PincerPayContextVariables }>();
+```
+
+> Released in lockstep with `@pincerpay/core`, `@pincerpay/agent`, and
+> `@pincerpay/mcp` 0.9.0. (Version 0.7.0 was skipped; the previous release was
+> 0.8.0.)

--- a/packages/merchant/README.md
+++ b/packages/merchant/README.md
@@ -184,6 +184,24 @@ app.post("/api/trade", async (c) => {
 
 The same `payer` field is also included in the base64-encoded `payment-response` response header for clients that bypass the middleware and post directly to `/v1/settle`.
 
+### Context contract
+
+The middleware sets **exactly one** Hono context variable: `pincerpay`, typed as
+`PincerPayPaymentInfo`. There is no `agentWallet` (or any other) context key - in
+the example above, `agentWallet` is just a field name on the caller's own
+`recordTrade(...)` function. Import the canonical type instead of duck-typing the
+shape, and you will fail at compile time if it ever changes:
+
+```typescript
+import type {
+  PincerPayContextVariables, // { pincerpay: PincerPayPaymentInfo }
+  PincerPayPaymentInfo,      // { payer: string; transaction: string; network: string }
+} from "@pincerpay/merchant"; // also re-exported from "@pincerpay/merchant/nextjs"
+```
+
+Any change to the keys the middleware sets, or to `PincerPayPaymentInfo`, will be
+called out in this package's [CHANGELOG](./CHANGELOG.md).
+
 ## API Reference
 
 ### `createPincerPayMiddleware(config): Hono.MiddlewareHandler`

--- a/packages/merchant/package.json
+++ b/packages/merchant/package.json
@@ -39,6 +39,7 @@
   "files": [
     "dist",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "main": "dist/index.js",

--- a/packages/merchant/src/index.ts
+++ b/packages/merchant/src/index.ts
@@ -1,2 +1,6 @@
 export { createPincerPayMiddleware } from "./middleware/nextjs.js";
+export type {
+  PincerPayContextVariables,
+  PincerPayPaymentInfo,
+} from "./middleware/nextjs.js";
 export { PincerPayClient, toBaseUnits, resolveRouteChains, getUsdcAsset } from "./client.js";


### PR DESCRIPTION
Response to the Fools integration feedback (consumer of `@pincerpay/agent`, `/core`, `/merchant`, `/mcp`). Per-item:

| # | Feedback | Resolution |
|---|----------|------------|
| 2 | Document version-coupling | New `RELEASING.md` (linked set; `merchant` pins `core` exact; 0.7 skipped; compatibility matrix). Coupling one-liner atop every package `CHANGELOG.md`. `pnpm changeset` added to the `Making Changes` checklist in `CONTRIBUTING.md`. |
| 3 | Export/stabilize merchant context contract | `PincerPayContextVariables` and `PincerPayPaymentInfo` now re-exported from `@pincerpay/merchant` root (was `/nextjs`-only). Docs state the middleware sets exactly one Hono context key: `pincerpay`. **The `agentWallet` Fools was duck-typing never existed** - it was a field name on a `recordTrade(...)` example in the README, not a context variable. Clarified in `packages/merchant/README.md` and `apps/dashboard/content/docs/merchant-sdk.md`. |
| 4 | Per-package CHANGELOG / MIGRATING | Root cause was a one-liner: `CHANGELOG.md` was **gitignored** (`.gitignore:46`), and not listed in any package's `files` array, so `changeset version` silently generated changelogs that never shipped to git or npm. Removed from `.gitignore`, added to all four `files` arrays, seeded `0.9.0` entries reconstructed from the consumed changesets. |
| 5 | MCP conventions | Added MCP `ToolAnnotations` (`readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`) to all 24 tools. Added a `confirm: true` guard on the only irreversible tool, `delete-paywall`. Wrote a "Conventions (for building your own MCP server)" section in `mcp-server.md`. Honestly flagged that a reusable spend-limit guard helper does not exist yet - left out per the prior scope decision, see "Open follow-ups" below. |
| 6 | Canonical x402 OpenAPI snippet | Added a `Describing x402 in OpenAPI` section to `x402.md`: `apiKey` security scheme in `X-PAYMENT`, 402 response component, **no `x-price-usd`** - the price is in the 402 body at `accepts[].amount` (USDC base units, 6 decimals). Recommended `x-pincerpay-price` vendor extension for static advertisement, mirroring `PincerPayConfig["routes"]`. |
| 7 | test/live key separation | **Already shipped**, not "coming". `environment` enum (`live`/`test`), `pp_live_` / `pp_test_` prefixes in `core/src/constants.ts`, CLI `--test`, DB trigger enforcing env match, test keys cannot settle on mainnet. Added a canonical "Test vs live keys" reference table to `api-reference.md` so downstream guides can say "do this." |

## Verification
- `pnpm --filter @pincerpay/core --filter @pincerpay/merchant --filter @pincerpay/mcp typecheck` - clean
- `pnpm --filter @pincerpay/merchant --filter @pincerpay/mcp test` - 49 tests passing
- `pnpm changeset status` - plans a clean linked **0.10.0** bump for `core`/`agent`/`merchant`/`mcp`, with `onboarding`/`cli` auto-bumped patch as dependents
- Em-dash convention respected (replaced all em dashes I'd introduced with hyphens to match the recent repo-wide cleanup)

## Open follow-ups (not in this PR)
- **Item 1 (publish 0.9.0).** `master` is at 0.9.0 but **0 git tags** and not on npm - the CI publish step in #138 never ran successfully (likely failed `build`/`test` or missing/expired `NPM_TOKEN`). I added a `release:next` script (`changeset publish --tag next`) and documented the flow in `RELEASING.md`, but the actual `npm publish` is owner-run. **Sequencing tip:** merging this PR queues `0.10.0`, so if you want Fools to validate the exact `0.9.0` bump, publish 0.9.0 (e.g. via `pnpm release:next` from `master`) **before** merging this PR.
- **Item 5 (spend-limit guard helper).** Deferred per the earlier scope decision - the MCP server here doesn't expose a money-spending tool, so the value is for downstream MCPs. Happy to implement as a follow-up if you want it.

## Test plan
- [ ] CI: typecheck, test, build all green
- [ ] `pnpm changeset status` shows linked 0.10.0 plan
- [ ] Inspect a published tarball locally (`pnpm pack --filter @pincerpay/merchant`) and confirm `CHANGELOG.md` is included
- [ ] Manually point a downstream consumer at `@pincerpay/merchant@next` (after `pnpm release:next`) and verify `import { PincerPayContextVariables } from "@pincerpay/merchant"` resolves
- [ ] Spot-check that an MCP client surfaces the new `destructiveHint` / `readOnlyHint` annotations
- [ ] Verify `delete-paywall` without `confirm=true` returns the refusal message; with `confirm=true` deletes as before

https://claude.ai/code/session_016KXJyLxeUUQ5LbXQTiegD8

---
_Generated by [Claude Code](https://claude.ai/code/session_016KXJyLxeUUQ5LbXQTiegD8)_