### PR TITLE
fix(facilitator): scope CLI bearer auth to /v1/onboarding/* (restore api-key surface)

### DIFF
--- a/apps/facilitator/src/__tests__/auth-routing.test.ts
+++ b/apps/facilitator/src/__tests__/auth-routing.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth.js";
+import { cliAuthMiddleware } from "../middleware/cli-auth.js";
+import type { AppEnv } from "../env.js";
+import type { Logger } from "../middleware/logging.js";
+import type { Database } from "@pincerpay/db";
+
+/**
+ * Regression guard for the CLI-bearer vs API-key middleware collision (#130).
+ *
+ * Two sub-apps mount at "/": `cliAuthenticated` (Authorization: Bearer, for the
+ * /v1/onboarding/* surface) and `authenticated` (x-pincerpay-api-key, for
+ * /v1/settle, /v1/verify, /v1/transactions, ...). Both register their auth
+ * middleware globally-ish, so the wiring is load-bearing:
+ *
+ *   - `authenticated.use("*", authMiddleware)` is global, so cliAuthenticated
+ *     must mount FIRST or onboarding requests get "Missing API key".
+ *   - because cliAuthenticated mounts first, its bearer middleware MUST be
+ *     scoped to "/v1/onboarding/*". A bare "*" matches every path and 401s the
+ *     entire api-key surface with "missing_bearer_token" (the #130 regression).
+ *
+ * This mirrors the mounting in index.ts (no app factory exists to import the
+ * real app yet — see follow-up). buildApp() is parameterized on the CLI pattern
+ * so the failure mode is encoded explicitly alongside the fix.
+ */
+function buildApp(cliPattern: string) {
+  // No-header requests short-circuit in both middlewares before any DB access,
+  // so a stub db is never dereferenced.
+  const db = {} as unknown as Database;
+  const noopLogger = { warn() {}, info() {}, error() {}, debug() {} } as unknown as Logger;
+
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("logger", noopLogger);
+    await next();
+  });
+
+  // Order + scope must match index.ts: cliAuthenticated first, scoped to onboarding.
+  const cliAuthenticated = new Hono<AppEnv>();
+  cliAuthenticated.use(cliPattern, cliAuthMiddleware(db));
+  cliAuthenticated.get("/v1/onboarding/health", (c) => c.json({ ok: true }));
+  app.route("/", cliAuthenticated);
+
+  const authenticated = new Hono<AppEnv>();
+  authenticated.use("*", authMiddleware(db));
+  authenticated.get("/v1/transactions", (c) => c.json({ ok: true }));
+  app.route("/", authenticated);
+
+  return app;
+}
+
+describe("facilitator auth routing (regression: #130 cli/api-key middleware scope)", () => {
+  it("scoped: an api-key path with no key reaches authMiddleware, not the CLI middleware", async () => {
+    const res = await buildApp("/v1/onboarding/*").request("/v1/transactions");
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Missing API key");
+  });
+
+  it("scoped: an onboarding path with no bearer reaches the CLI middleware", async () => {
+    const res = await buildApp("/v1/onboarding/*").request("/v1/onboarding/health");
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("missing_bearer_token");
+  });
+
+  it("regression: a bare \"*\" CLI pattern hijacks the api-key surface (the #130 bug)", async () => {
+    const res = await buildApp("*").request("/v1/transactions");
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    // With "*" the CLI bearer middleware (mounted first) intercepts every path.
+    expect(body.error).toBe("missing_bearer_token");
+  });
+});

--- a/apps/facilitator/src/index.ts
+++ b/apps/facilitator/src/index.ts
@@ -298,8 +298,9 @@ authenticated.route("/", createWebhookRoutes(db));
 authenticated.route("/", createMerchantRoute(db));
 
 // CLI onboarding — authenticated endpoints (merchant management, api keys, sessions).
-// Mounted under a separate sub-app so the cliAuthMiddleware is scoped to these
-// routes and does not apply to the existing pp_live_* api-key paths.
+// The cliAuthMiddleware below is scoped to "/v1/onboarding/*", NOT "*":
+// mounting in a sub-app does NOT scope a "*" use(); once mounted at "/" it
+// matches every path and 401s the pp_live_* api-key surface.
 //
 // IMPORTANT: must mount BEFORE `authenticated` because Hono evaluates merged
 // routes/middleware in registration order. `authenticated.use("*", authMiddleware)`
@@ -314,7 +315,10 @@ if (onboardingEnabled) {
     }
     return next();
   });
-  cliAuthenticated.use("*", cliAuthMiddleware(db));
+  // Scope to onboarding paths only. A bare "*" matches every request once this
+  // sub-app is mounted at "/", which 401s the whole pp_live_* api-key surface
+  // (/v1/settle, /v1/verify, etc.) with `missing_bearer_token`. Regression #130.
+  cliAuthenticated.use("/v1/onboarding/*", cliAuthMiddleware(db));
   cliAuthenticated.route("/", createMerchantOnboardingRoute(db));
   cliAuthenticated.route("/", createApiKeysOnboardingRoute(db));
   cliAuthenticated.route("/", createSessionsOnboardingRoute(db));


### PR DESCRIPTION
## Incident — API-key surface down in production

Every `x-pincerpay-api-key` endpoint on `facilitator.pincerpay.com` — including the core payment path `/v1/settle` and `/v1/verify` — returns `401 {"error":"missing_bearer_token"}`. Any agent/merchant using an API key (the `@pincerpay/merchant` SDK, the demo, integrators) is broken against the live facilitator.

## Root cause

`cliAuthMiddleware` is registered on `"*"`, and the `cliAuthenticated` sub-app mounts **before** `authenticated`. Once mounted at `/`, a `"*"` `use()` matches every path, so the CLI bearer check runs first for all requests and 401s anything without an `Authorization: Bearer` header — before the API-key `authMiddleware` is reached.

#130 ("mount cliAuthenticated before authenticated") fixed the inverse symptom (onboarding routes shadowed by `authMiddleware` → `Missing API key`) by reordering. But both sub-apps use `.use("*")`, so reordering only moved the breakage from the onboarding surface to the more critical payment surface.

## Fix

Scope `cliAuthMiddleware` to `/v1/onboarding/*` (every onboarding route already lives under that prefix — verified). The #130 ordering stays; it's still needed so onboarding handlers respond before the global `authMiddleware`. With both in place, each surface's middleware only affects its own paths.

## Test

`apps/facilitator/src/__tests__/auth-routing.test.ts` mirrors the index.ts mounting and asserts:
- api-key path, no key -> `Missing API key` (authMiddleware), not `missing_bearer_token`
- onboarding path, no bearer -> `missing_bearer_token` (cliAuthMiddleware)
- a bare `"*"` CLI pattern -> hijacks the api-key surface (documents the bug)

Note: the test mirrors the mounting rather than importing the real app (no app factory exists yet). A follow-up to extract a route factory would let it guard `index.ts` directly.

## Deploy

Merging to `master` triggers the Railway facilitator auto-deploy. After deploy, verify with an API key against `/v1/merchant` (expect `200`, not `401`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
