### PR TITLE
chore: warn when admin/bootstrap mint API keys without TOKEN_PEPPER (#133)

### DIFF
--- a/.changeset/onboarding-pepper-warning.md
+++ b/.changeset/onboarding-pepper-warning.md
@@ -1,0 +1,5 @@
+---
+"@pincerpay/onboarding": patch
+---
+
+Warn (on stderr) when minting an API key without `TOKEN_PEPPER` set, which mints a legacy SHA-256 key via fallback instead of an HMAC key. Surfaces a missing pepper to operators running `bootstrap-merchant` so it isn't silently misconfigured (#133).

--- a/packages/onboarding/src/merchant.ts
+++ b/packages/onboarding/src/merchant.ts
@@ -182,6 +182,12 @@ async function mintApiKey(
   const prefixWord = environment === "test" ? "pp_test_" : "pp_live_";
   const rawKey = `${prefixWord}${randomBytes(32).toString("hex")}`;
   const { keyHash, keyHashHmac } = hashNewApiKey(rawKey);
+  if (!keyHashHmac) {
+    console.warn(
+      "[pincerpay] TOKEN_PEPPER not set (or under 32 chars): minted a legacy SHA-256 API key. " +
+        "It works via fallback, but set TOKEN_PEPPER (same value as the facilitator) to mint HMAC keys. See issue #133.",
+    );
+  }
   const prefix = rawKey.slice(0, API_KEY_PREFIX_LENGTH);
 
   await db.insert(apiKeys).values({

--- a/scripts/create-api-key.mts
+++ b/scripts/create-api-key.mts
@@ -20,6 +20,12 @@ Examples:
   pnpm create-api-key create --merchant Fools --label "Fools staging"
   pnpm create-api-key create --merchant 7d9a... --label "production" --dry-run
 
+Environment:
+  DATABASE_URL    Required. Postgres connection string.
+  TOKEN_PEPPER    Recommended. HMAC pepper, identical to the facilitator's value.
+                  When set (>=32 chars) keys are minted as HMAC; otherwise a
+                  legacy SHA-256 key is minted (works via fallback). See #133.
+
 The raw key is printed once. It is never recoverable. Save it immediately.
 `.trim();
 
@@ -102,6 +108,13 @@ async function createKey(opts: {
 
     const rawKey = `pp_live_${randomBytes(32).toString("hex")}`;
     const { keyHash, keyHashHmac } = hashNewApiKey(rawKey);
+    if (!keyHashHmac) {
+      console.warn(
+        "WARNING: TOKEN_PEPPER not set (or under 32 chars). Minting a legacy SHA-256 key.\n" +
+          "         It works via fallback, but set TOKEN_PEPPER (same value as the facilitator)\n" +
+          "         to mint HMAC keys. See issue #133.",
+      );
+    }
     const prefix = rawKey.slice(0, API_KEY_PREFIX_LENGTH);
 
     if (opts.dryRun) {


### PR DESCRIPTION
## What

Adds a loud warning at the two direct-DB API-key mint sites when `TOKEN_PEPPER` is absent — i.e. when they fall back to minting a legacy SHA-256 key instead of an HMAC key:

- `scripts/create-api-key.mts` (admin key creation) — `console.warn` + a `TOKEN_PEPPER` note in the `--help` usage.
- `packages/onboarding/src/merchant.ts` (`mintApiKey`, used by `bootstrap-merchant`) — `console.warn` to stderr.

Changeset: `@pincerpay/onboarding` patch.

## Why

Part of #133 (the #124/#135 HMAC rollout). These paths silently fall back to SHA-256 when no pepper is set, so a misconfigured operator/CI environment would mint legacy keys with no signal. The warning surfaces it. No other behavior change — the key is still minted and works via the facilitator's fallback.

## What this does NOT do

This is the safety-net half of #133. The operational half — exporting `TOKEN_PEPPER` (same value as the facilitator) wherever `pnpm create-api-key` / `pnpm bootstrap-merchant` actually run (operator shell `.env`, any CI secret) — is environment config, not code. #133 stays open until that's in place.

## Test

`@pincerpay/onboarding` typecheck + 7 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
