### PR TITLE
Facilitator: buildApp factory + /v1/supported testnet scoping; accept lodash advisory

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,12 @@ If you discover a security vulnerability in PincerPay, please report it using [G
 - Third-party dependencies (report upstream; notify us if it affects PincerPay)
 - Issues in test/example code that don't affect production
 
+## Accepted advisories (audit exceptions)
+
+After assessment, the following advisories are suppressed in `pnpm.auditConfig.ignoreGhsas` (root `package.json`). Each is re-reviewed when an upstream fix ships.
+
+- **GHSA-r5fr-rjxr-66jc** — `lodash` code injection via `_.template`. Transitive and build-only: `apps/dashboard > recharts > lodash`. The vulnerable sink (`_.template`) is never reached (recharts uses lodash for chart-math utilities only), and the dashboard is a private app, not a published package. No upstream fix exists — the advisory cites `>=4.18.0`, which lodash has never released (latest is 4.17.21). Permanent resolution tracked in #154: upgrade `recharts` to v3, which drops the bundled `lodash` dependency.
+
 ## Disclosure Policy
 
 - We will coordinate disclosure timelines with you

--- a/apps/facilitator/src/__tests__/auth-routing.test.ts
+++ b/apps/facilitator/src/__tests__/auth-routing.test.ts
@@ -1,75 +1,33 @@
 import { describe, it, expect } from "vitest";
-import { Hono } from "hono";
-import { authMiddleware } from "../middleware/auth.js";
-import { cliAuthMiddleware } from "../middleware/cli-auth.js";
-import type { AppEnv } from "../env.js";
-import type { Logger } from "../middleware/logging.js";
-import type { Database } from "@pincerpay/db";
+import { buildTestApp } from "./test-app.js";
 
 /**
- * Regression guard for the CLI-bearer vs API-key middleware collision (#130).
+ * Regression guard for the CLI-bearer vs API-key middleware collision
+ * (#130 / #149), asserted against the REAL app from buildApp().
  *
- * Two sub-apps mount at "/": `cliAuthenticated` (Authorization: Bearer, for the
- * /v1/onboarding/* surface) and `authenticated` (x-pincerpay-api-key, for
- * /v1/settle, /v1/verify, /v1/transactions, ...). Both register their auth
- * middleware globally-ish, so the wiring is load-bearing:
+ * buildApp mounts two sub-apps at "/": `cliAuthenticated` (Authorization:
+ * Bearer, scoped to /v1/onboarding/*) and `authenticated` (x-pincerpay-api-key,
+ * for /v1/settle, /v1/verify, /v1/transactions, ...). The wiring is load-bearing:
+ * cliAuthenticated mounts first, so its bearer middleware MUST be scoped to
+ * /v1/onboarding/*. A bare "*" there 401s the entire api-key surface with
+ * "missing_bearer_token" — the #130 regression that broke payments in prod (#149).
  *
- *   - `authenticated.use("*", authMiddleware)` is global, so cliAuthenticated
- *     must mount FIRST or onboarding requests get "Missing API key".
- *   - because cliAuthenticated mounts first, its bearer middleware MUST be
- *     scoped to "/v1/onboarding/*". A bare "*" matches every path and 401s the
- *     entire api-key surface with "missing_bearer_token" (the #130 regression).
- *
- * This mirrors the mounting in index.ts (no app factory exists to import the
- * real app yet — see follow-up). buildApp() is parameterized on the CLI pattern
- * so the failure mode is encoded explicitly alongside the fix.
+ * These run the real buildApp, so a future change that rescopes or reorders the
+ * auth middleware fails here directly (the mirror-based version could not).
  */
-function buildApp(cliPattern: string) {
-  // No-header requests short-circuit in both middlewares before any DB access,
-  // so a stub db is never dereferenced.
-  const db = {} as unknown as Database;
-  const noopLogger = { warn() {}, info() {}, error() {}, debug() {} } as unknown as Logger;
-
-  const app = new Hono<AppEnv>();
-  app.use("*", async (c, next) => {
-    c.set("logger", noopLogger);
-    await next();
-  });
-
-  // Order + scope must match index.ts: cliAuthenticated first, scoped to onboarding.
-  const cliAuthenticated = new Hono<AppEnv>();
-  cliAuthenticated.use(cliPattern, cliAuthMiddleware(db));
-  cliAuthenticated.get("/v1/onboarding/health", (c) => c.json({ ok: true }));
-  app.route("/", cliAuthenticated);
-
-  const authenticated = new Hono<AppEnv>();
-  authenticated.use("*", authMiddleware(db));
-  authenticated.get("/v1/transactions", (c) => c.json({ ok: true }));
-  app.route("/", authenticated);
-
-  return app;
-}
-
-describe("facilitator auth routing (regression: #130 cli/api-key middleware scope)", () => {
-  it("scoped: an api-key path with no key reaches authMiddleware, not the CLI middleware", async () => {
-    const res = await buildApp("/v1/onboarding/*").request("/v1/transactions");
+describe("facilitator auth routing (regression #130/#149)", () => {
+  it("an api-key path with no key reaches authMiddleware, not the CLI bearer middleware", async () => {
+    const res = await buildTestApp().request("/v1/transactions");
     expect(res.status).toBe(401);
     const body = (await res.json()) as { error: string };
+    // The #149 regression answered this api-key path with "missing_bearer_token".
     expect(body.error).toBe("Missing API key");
   });
 
-  it("scoped: an onboarding path with no bearer reaches the CLI middleware", async () => {
-    const res = await buildApp("/v1/onboarding/*").request("/v1/onboarding/health");
+  it("an onboarding path with no bearer reaches the CLI bearer middleware", async () => {
+    const res = await buildTestApp().request("/v1/onboarding/health");
     expect(res.status).toBe(401);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe("missing_bearer_token");
-  });
-
-  it("regression: a bare \"*\" CLI pattern hijacks the api-key surface (the #130 bug)", async () => {
-    const res = await buildApp("*").request("/v1/transactions");
-    expect(res.status).toBe(401);
-    const body = (await res.json()) as { error: string };
-    // With "*" the CLI bearer middleware (mounted first) intercepts every path.
     expect(body.error).toBe("missing_bearer_token");
   });
 });

--- a/apps/facilitator/src/__tests__/e2e-solana-payment.test.ts
+++ b/apps/facilitator/src/__tests__/e2e-solana-payment.test.ts
@@ -347,7 +347,7 @@ async function buildSolanaFacilitatorApp(
       },
     }),
   );
-  app.route("/", createSupportedRoute(facilitator));
+  app.route("/", createSupportedRoute(facilitator, { networks: [TEST_CHAIN] }));
 
   // Authenticated routes
   const authenticated = new Hono<AppEnv>();

--- a/apps/facilitator/src/__tests__/e2e.test.ts
+++ b/apps/facilitator/src/__tests__/e2e.test.ts
@@ -212,7 +212,7 @@ function buildFacilitatorApp(
   // Public routes
   const mockWorkerStatus = { getStatus: () => ({ running: false, lastCycleAt: null, cycleCount: 0, consecutiveErrors: 0, lastError: null }) };
   app.route("/", createHealthRoute({ db: mockDb, workers: { confirmation: mockWorkerStatus, webhookRetry: mockWorkerStatus } }));
-  app.route("/", createSupportedRoute(facilitator));
+  app.route("/", createSupportedRoute(facilitator, { networks: [TEST_CHAIN] }));
 
   // Authenticated routes
   const authenticated = new Hono<AppEnv>();

--- a/apps/facilitator/src/__tests__/supported.test.ts
+++ b/apps/facilitator/src/__tests__/supported.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { allowedSupportedNetworks } from "../routes/supported.js";
+import { buildTestApp } from "./test-app.js";
+
+const DEVNET_SOLANA = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
+const BASE_SEPOLIA = "eip155:84532";
+
+describe("allowedSupportedNetworks", () => {
+  it("includes each configured CAIP-2 id and its x402-v1 short-name alias", () => {
+    const allowed = allowedSupportedNetworks([DEVNET_SOLANA, BASE_SEPOLIA]);
+    expect(allowed.has(DEVNET_SOLANA)).toBe(true);
+    expect(allowed.has(BASE_SEPOLIA)).toBe(true);
+    expect(allowed.has("solana-devnet")).toBe(true);
+    expect(allowed.has("base-sepolia")).toBe(true);
+    // Mainnet names are never derived from a testnet config.
+    expect(allowed.has("base")).toBe(false);
+    expect(allowed.has("solana")).toBe(false);
+  });
+});
+
+describe("/v1/supported (testnet-only scoping)", () => {
+  it("drops advertised kinds for networks this facilitator is not configured for", async () => {
+    const app = buildTestApp({
+      supportedNetworks: [DEVNET_SOLANA, BASE_SEPOLIA],
+      supportedKinds: [
+        // What this deploy actually settles on (v2 CAIP-2 + v1 aliases):
+        { x402Version: 2, scheme: "exact", network: DEVNET_SOLANA },
+        { x402Version: 2, scheme: "exact", network: BASE_SEPOLIA },
+        { x402Version: 1, scheme: "exact", network: "solana-devnet" },
+        { x402Version: 1, scheme: "exact", network: "base-sepolia" },
+        // Over-advertised mainnets / unrelated testnets from the @x402 registry:
+        { x402Version: 1, scheme: "exact", network: "solana" },
+        { x402Version: 1, scheme: "exact", network: "ethereum" },
+        { x402Version: 1, scheme: "exact", network: "base" },
+        { x402Version: 1, scheme: "exact", network: "polygon" },
+        { x402Version: 1, scheme: "exact", network: "avalanche" },
+      ],
+    });
+
+    const res = await app.request("/v1/supported");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { kinds: Array<{ network: string }> };
+    const networks = body.kinds.map((k) => k.network).sort();
+
+    expect(networks).toEqual(
+      [BASE_SEPOLIA, DEVNET_SOLANA, "base-sepolia", "solana-devnet"].sort(),
+    );
+    for (const mainnet of ["solana", "ethereum", "base", "polygon", "avalanche"]) {
+      expect(networks).not.toContain(mainnet);
+    }
+  });
+});

--- a/apps/facilitator/src/__tests__/test-app.ts
+++ b/apps/facilitator/src/__tests__/test-app.ts
@@ -1,0 +1,61 @@
+// Shared test harness: constructs the REAL facilitator app via buildApp() with
+// lightweight stub dependencies, so route + middleware wiring (mount order, auth
+// scoping, /v1/supported filtering) is asserted against production code rather
+// than a mirror. No-header requests short-circuit in the auth middlewares before
+// any DB access, so the stub db is never dereferenced.
+import type { Hono } from "hono";
+import { buildApp, type BuildAppDeps } from "../app.js";
+import type { AppEnv } from "../env.js";
+import type { Config } from "../config.js";
+import type { Logger } from "../middleware/logging.js";
+import type { Metrics } from "../metrics.js";
+import type { Database } from "@pincerpay/db";
+import type { x402Facilitator } from "@x402/core/facilitator";
+
+const noop = () => {};
+
+const stubWorker = {
+  nudge: noop,
+  stop: async () => {},
+} as unknown as BuildAppDeps["workers"]["confirmation"];
+
+export interface TestAppOverrides {
+  supportedKinds?: Array<{ x402Version: number; scheme: string; network: string }>;
+  supportedNetworks?: string[];
+  onboardingEnabled?: boolean;
+  isShuttingDown?: () => boolean;
+}
+
+export function buildTestApp(overrides: TestAppOverrides = {}): Hono<AppEnv> {
+  const db = {} as unknown as Database;
+  const logger = { warn: noop, info: noop, error: noop, debug: noop } as unknown as Logger;
+  const facilitator = {
+    getSupported: () => ({
+      kinds: overrides.supportedKinds ?? [],
+      extensions: [],
+      signers: {},
+    }),
+  } as unknown as x402Facilitator;
+
+  return buildApp({
+    config: {
+      CORS_ORIGINS: undefined,
+      RATE_LIMIT_PER_MINUTE: 1000,
+      SUPABASE_SMTP_CONFIGURED: false,
+    } as unknown as Config,
+    db,
+    facilitator,
+    metrics: {} as unknown as Metrics,
+    logger,
+    workers: {
+      confirmation: stubWorker,
+      webhookRetry: stubWorker,
+      onChainRecorder: undefined,
+    },
+    koraEnabled: false,
+    onboardingEnabled: overrides.onboardingEnabled ?? true,
+    solanaRpcUrl: "https://api.devnet.solana.com",
+    supportedNetworks: overrides.supportedNetworks ?? [],
+    isShuttingDown: overrides.isShuttingDown ?? (() => false),
+  });
+}

--- a/apps/facilitator/src/app.ts
+++ b/apps/facilitator/src/app.ts
@@ -1,0 +1,229 @@
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import type { x402Facilitator } from "@x402/core/facilitator";
+import type { Database } from "@pincerpay/db";
+import type { Config } from "./config.js";
+import type { Logger } from "./middleware/logging.js";
+import type { Metrics } from "./metrics.js";
+import type { OfacSdnProvider } from "./compliance/ofac-sdn.js";
+import type { AppEnv } from "./env.js";
+import { loggingMiddleware } from "./middleware/logging.js";
+import { authMiddleware } from "./middleware/auth.js";
+import { rateLimitMiddleware, routeRateLimitMiddleware } from "./middleware/ratelimit.js";
+import { cliAuthMiddleware } from "./middleware/cli-auth.js";
+import { complianceMiddleware } from "./compliance/middleware.js";
+import { squadsMiddleware } from "./middleware/squads.js";
+import { createHealthRoute } from "./routes/health.js";
+import { createSupportedRoute } from "./routes/supported.js";
+import { createVerifyRoute } from "./routes/verify.js";
+import { createSettleRoute } from "./routes/settle.js";
+import { createSettleDirectRoute } from "./routes/settle-direct.js";
+import { createStatusRoute } from "./routes/status.js";
+import { createOpenApiRoute } from "./routes/openapi.js";
+import { createMetricsRoute } from "./routes/metrics.js";
+import { createPaywallRoutes } from "./routes/paywalls.js";
+import { createTransactionListRoute } from "./routes/transactions-list.js";
+import { createAgentRoutes } from "./routes/agents.js";
+import { createWebhookRoutes } from "./routes/webhooks.js";
+import { createMerchantRoute } from "./routes/merchant.js";
+import { createAuthRoute } from "./routes/onboarding/auth.js";
+import { createMerchantOnboardingRoute } from "./routes/onboarding/merchant.js";
+import { createApiKeysOnboardingRoute } from "./routes/onboarding/api-keys.js";
+import { createSessionsOnboardingRoute } from "./routes/onboarding/sessions.js";
+import { createOnboardingHealthRoute } from "./routes/onboarding/health.js";
+
+type ConfirmationWorker = ReturnType<
+  typeof import("./workers/confirmation.js").startConfirmationWorker
+>;
+type WebhookRetryWorker = ReturnType<
+  typeof import("./webhooks/dispatcher.js").startWebhookRetryWorker
+>;
+type OnChainRecorderWorker = ReturnType<
+  typeof import("./workers/on-chain-recorder.js").startOnChainRecorderWorker
+>;
+type AnchorIntegration = ReturnType<
+  typeof import("./chains/solana-anchor.js").setupAnchorIntegration
+>;
+
+export interface BuildAppDeps {
+  config: Config;
+  db: Database;
+  facilitator: x402Facilitator;
+  metrics: Metrics;
+  logger: Logger;
+  workers: {
+    confirmation: ConfirmationWorker;
+    webhookRetry: WebhookRetryWorker;
+    onChainRecorder?: OnChainRecorderWorker;
+  };
+  koraEnabled: boolean;
+  koraFeePayer?: string;
+  anchorIntegration?: AnchorIntegration;
+  ofacProvider?: OfacSdnProvider;
+  onboardingEnabled: boolean;
+  /** RPC URL for the primary Solana network (Squads validation). */
+  solanaRpcUrl: string;
+  /** Configured networks (CAIP-2) — used to scope the /v1/supported advertisement. */
+  supportedNetworks: string[];
+  /** True once SIGTERM/SIGINT drain has started. Owned by the server bootstrap. */
+  isShuttingDown: () => boolean;
+}
+
+/**
+ * Build the facilitator Hono app from already-constructed dependencies.
+ *
+ * This is intentionally free of side effects (no server, DB connection, or
+ * worker startup) so the real route + middleware wiring — including the
+ * load-bearing mount order below — can be imported and asserted in tests.
+ * `index.ts` owns the bootstrap (config, signers, workers, shutdown) and the
+ * server lifecycle.
+ */
+export function buildApp(deps: BuildAppDeps): Hono<AppEnv> {
+  const {
+    config,
+    db,
+    facilitator,
+    metrics,
+    logger,
+    workers,
+    koraEnabled,
+    koraFeePayer,
+    anchorIntegration,
+    ofacProvider,
+    onboardingEnabled,
+    solanaRpcUrl,
+    supportedNetworks,
+    isShuttingDown,
+  } = deps;
+
+  const app = new Hono<AppEnv>();
+
+  // Global middleware
+  app.use(
+    "*",
+    cors({
+      origin: config.CORS_ORIGINS
+        ? config.CORS_ORIGINS.split(",").map((o) => o.trim())
+        : "*",
+    }),
+  );
+  app.use("*", loggingMiddleware(logger));
+
+  // Health check (no auth) — includes DB, worker status, uptime
+  app.route("/", createHealthRoute({
+    db,
+    koraFeePayer,
+    workers: {
+      confirmation: workers.confirmation,
+      webhookRetry: workers.webhookRetry,
+      onChainRecorder: workers.onChainRecorder,
+    },
+    isShuttingDown,
+    ...(ofacProvider && { compliance: { provider: ofacProvider } }),
+  }));
+
+  // Public endpoints (no auth). /v1/supported is scoped to the configured
+  // networks so a testnet-only deploy does not advertise mainnets.
+  app.route("/", createSupportedRoute(facilitator, { networks: supportedNetworks }));
+  app.route("/", createMetricsRoute(metrics));
+  app.route("/", createOpenApiRoute());
+
+  // CLI onboarding — public auth endpoints (signup, verify, login, recover, reset).
+  // Each route is IP-rate-limited internally. Only mounts when Supabase + token
+  // pepper config is present; otherwise the caller logged the disabled warning.
+  if (onboardingEnabled) {
+    app.route("/", createAuthRoute(db, { smtpConfigured: !!config.SUPABASE_SMTP_CONFIGURED }));
+  }
+
+  // Authenticated endpoints
+  const authenticated = new Hono<AppEnv>();
+
+  // Reject new requests during graceful shutdown drain
+  authenticated.use("*", async (c, next) => {
+    if (isShuttingDown()) {
+      c.header("Retry-After", "1");
+      return c.json({ error: "Service is shutting down, retry on another instance" }, 503);
+    }
+    return next();
+  });
+
+  authenticated.use("*", authMiddleware(db));
+  authenticated.use("*", rateLimitMiddleware(config.RATE_LIMIT_PER_MINUTE));
+
+  // Route-specific rate limits (stricter than global)
+  authenticated.use("/v1/settle", routeRateLimitMiddleware("settle", 50));
+  authenticated.use("/v1/settle-direct", routeRateLimitMiddleware("settle", 50));
+  authenticated.use("/v1/verify", routeRateLimitMiddleware("verify", 100));
+
+  // OFAC compliance screening on settlement routes
+  if (ofacProvider) {
+    authenticated.use("/v1/settle", complianceMiddleware(ofacProvider));
+    authenticated.use("/v1/settle-direct", complianceMiddleware(ofacProvider));
+  }
+
+  // Squads SPN spending limit validation (Solana payments only)
+  authenticated.use("/v1/settle", squadsMiddleware({ db, rpcUrl: solanaRpcUrl }));
+  authenticated.use("/v1/settle-direct", squadsMiddleware({ db, rpcUrl: solanaRpcUrl }));
+
+  authenticated.route("/", createVerifyRoute(facilitator, { metrics }));
+  authenticated.route("/", createSettleRoute(facilitator, db, {
+    koraEnabled,
+    metrics,
+    solanaRpcUrl,
+    onSettle: () => {
+      workers.confirmation.nudge();
+      workers.webhookRetry.nudge();
+      workers.onChainRecorder?.nudge();
+    },
+  }));
+  if (anchorIntegration) {
+    authenticated.route("/", createSettleDirectRoute(db, {
+      program: anchorIntegration.program,
+      koraEnabled,
+    }));
+  }
+  authenticated.route("/", createStatusRoute(db));
+
+  // CRUD + management routes (Phase 2/3)
+  authenticated.use("/v1/paywalls", routeRateLimitMiddleware("paywalls-write", 30));
+  authenticated.use("/v1/agents", routeRateLimitMiddleware("agents-write", 30));
+  authenticated.use("/v1/webhooks", routeRateLimitMiddleware("webhooks", 30));
+  authenticated.route("/", createPaywallRoutes(db));
+  authenticated.route("/", createTransactionListRoute(db));
+  authenticated.route("/", createAgentRoutes(db));
+  authenticated.route("/", createWebhookRoutes(db));
+  authenticated.route("/", createMerchantRoute(db));
+
+  // CLI onboarding — authenticated endpoints (merchant management, api keys, sessions).
+  // The cliAuthMiddleware below is scoped to "/v1/onboarding/*", NOT "*":
+  // mounting in a sub-app does NOT scope a "*" use(); once mounted at "/" it
+  // matches every path and 401s the pp_live_* api-key surface.
+  //
+  // IMPORTANT: must mount BEFORE `authenticated` because Hono evaluates merged
+  // routes/middleware in registration order. `authenticated.use("*", authMiddleware)`
+  // would otherwise intercept every onboarding request with `Missing API key`
+  // before cliAuthMiddleware could see it.
+  if (onboardingEnabled) {
+    const cliAuthenticated = new Hono<AppEnv>();
+    cliAuthenticated.use("*", async (c, next) => {
+      if (isShuttingDown()) {
+        c.header("Retry-After", "1");
+        return c.json({ error: "Service is shutting down, retry on another instance" }, 503);
+      }
+      return next();
+    });
+    // Scope to onboarding paths only. A bare "*" matches every request once this
+    // sub-app is mounted at "/", which 401s the whole pp_live_* api-key surface
+    // (/v1/settle, /v1/verify, etc.) with `missing_bearer_token`. Regression #130.
+    cliAuthenticated.use("/v1/onboarding/*", cliAuthMiddleware(db));
+    cliAuthenticated.route("/", createMerchantOnboardingRoute(db));
+    cliAuthenticated.route("/", createApiKeysOnboardingRoute(db));
+    cliAuthenticated.route("/", createSessionsOnboardingRoute(db));
+    cliAuthenticated.route("/", createOnboardingHealthRoute(db));
+    app.route("/", cliAuthenticated);
+  }
+
+  app.route("/", authenticated);
+
+  return app;
+}

--- a/apps/facilitator/src/index.ts
+++ b/apps/facilitator/src/index.ts
@@ -1,44 +1,19 @@
-import { Hono } from "hono";
-import { cors } from "hono/cors";
 import { x402Facilitator } from "@x402/core/facilitator";
 import { createDb } from "@pincerpay/db";
+import { serve } from "@hono/node-server";
 import { loadConfig, parseRpcUrls } from "./config.js";
-import { createLogger, loggingMiddleware } from "./middleware/logging.js";
-import { authMiddleware } from "./middleware/auth.js";
-import { rateLimitMiddleware, routeRateLimitMiddleware } from "./middleware/ratelimit.js";
+import { createLogger } from "./middleware/logging.js";
+import { parseNetworks, groupByNamespace } from "./chains/registry.js";
 import { setupEvmFacilitator } from "./chains/evm.js";
 import { setupSolanaFacilitator, setupSolanaFacilitatorWithKora } from "./chains/solana.js";
-import { parseNetworks, groupByNamespace } from "./chains/registry.js";
-import { createHealthRoute } from "./routes/health.js";
-import { createSupportedRoute } from "./routes/supported.js";
-import { createVerifyRoute } from "./routes/verify.js";
-import { createSettleRoute } from "./routes/settle.js";
-import { createSettleDirectRoute } from "./routes/settle-direct.js";
-import { createStatusRoute } from "./routes/status.js";
-import { createOpenApiRoute } from "./routes/openapi.js";
-import { createMetricsRoute } from "./routes/metrics.js";
-import { createPaywallRoutes } from "./routes/paywalls.js";
-import { createTransactionListRoute } from "./routes/transactions-list.js";
-import { createAgentRoutes } from "./routes/agents.js";
-import { createWebhookRoutes } from "./routes/webhooks.js";
-import { createMerchantRoute } from "./routes/merchant.js";
-import { createAuthRoute } from "./routes/onboarding/auth.js";
-import { createMerchantOnboardingRoute } from "./routes/onboarding/merchant.js";
-import { createApiKeysOnboardingRoute } from "./routes/onboarding/api-keys.js";
-import { createSessionsOnboardingRoute } from "./routes/onboarding/sessions.js";
-import { createOnboardingHealthRoute } from "./routes/onboarding/health.js";
-import { cliAuthMiddleware } from "./middleware/cli-auth.js";
-import { startCleanup } from "./lib/cleanup.js";
-import { Metrics } from "./metrics.js";
-import { serve } from "@hono/node-server";
-import { startConfirmationWorker } from "./workers/confirmation.js";
 import { setupAnchorIntegration } from "./chains/solana-anchor.js";
+import { startConfirmationWorker } from "./workers/confirmation.js";
 import { startOnChainRecorderWorker } from "./workers/on-chain-recorder.js";
 import { startWebhookRetryWorker } from "./webhooks/dispatcher.js";
+import { startCleanup } from "./lib/cleanup.js";
 import { OfacSdnProvider } from "./compliance/ofac-sdn.js";
-import { complianceMiddleware } from "./compliance/middleware.js";
-import { squadsMiddleware } from "./middleware/squads.js";
-import type { AppEnv } from "./env.js";
+import { Metrics } from "./metrics.js";
+import { buildApp } from "./app.js";
 
 const config = loadConfig();
 const logger = createLogger(config.LOG_LEVEL, config.LOGTAIL_SOURCE_TOKEN);
@@ -71,6 +46,7 @@ const evmNetworks = config.EVM_NETWORKS ? parseNetworks(config.EVM_NETWORKS) : [
 const allNetworks = [...solanaNetworks, ...evmNetworks];
 const grouped = groupByNamespace(allNetworks);
 const rpcUrls = parseRpcUrls(config.RPC_URLS);
+const solanaRpcUrl = rpcUrls[solanaNetworks[0]] ?? "https://api.devnet.solana.com";
 
 // Track whether Kora is active (affects gas token reporting)
 let koraEnabled = false;
@@ -134,7 +110,6 @@ if (grouped.eip155.length > 0 && config.FACILITATOR_PRIVATE_KEY) {
 let anchorIntegration: ReturnType<typeof setupAnchorIntegration> | undefined;
 
 if (config.ANCHOR_PROGRAM_ID) {
-  const solanaRpcUrl = rpcUrls[solanaNetworks[0]] ?? "https://api.devnet.solana.com";
   anchorIntegration = setupAnchorIntegration({
     programId: config.ANCHOR_PROGRAM_ID,
     rpcUrl: solanaRpcUrl,
@@ -193,140 +168,39 @@ if (config.OFAC_ENABLED) {
   logger.info({ msg: "ofac_compliance_enabled", refreshIntervalMs: config.OFAC_REFRESH_INTERVAL_MS });
 }
 
-// ─── Hono App ───
-const app = new Hono<AppEnv>();
-
-// Global middleware
-app.use(
-  "*",
-  cors({
-    origin: config.CORS_ORIGINS
-      ? config.CORS_ORIGINS.split(",").map((o) => o.trim())
-      : "*",
-  }),
-);
-app.use("*", loggingMiddleware(logger));
-
-// Health check (no auth) — includes DB, worker status, uptime
-app.route("/", createHealthRoute({
-  db,
-  koraFeePayer,
-  workers: {
-    confirmation: confirmationWorker,
-    webhookRetry: webhookRetryWorker,
-    onChainRecorder: onChainRecorderWorker,
-  },
-  isShuttingDown: () => shuttingDown,
-  ...(ofacProvider && { compliance: { provider: ofacProvider } }),
-}));
-
-// Public endpoints (no auth)
-app.route("/", createSupportedRoute(facilitator));
-app.route("/", createMetricsRoute(metrics));
-app.route("/", createOpenApiRoute());
-
-// CLI onboarding — public auth endpoints (signup, verify, login, recover, reset).
-// Each route is IP-rate-limited internally. Only mounts when Supabase + token
-// pepper config is present; otherwise the warning above already fired.
-if (onboardingEnabled) {
-  app.route("/", createAuthRoute(db, { smtpConfigured: !!config.SUPABASE_SMTP_CONFIGURED }));
-} else {
+if (!onboardingEnabled) {
   logger.warn({
     msg: "onboarding_disabled_missing_config",
     hint: "Set SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, TOKEN_PEPPER to enable CLI onboarding.",
   });
 }
 
-// Authenticated endpoints
-const authenticated = new Hono<AppEnv>();
+// ─── Graceful shutdown state ───
+// Owned here (the server lifecycle) and read by the app via the injected
+// isShuttingDown() — the health route and the drain middleware in buildApp.
+let shuttingDown = false;
 
-// Reject new requests during graceful shutdown drain
-authenticated.use("*", async (c, next) => {
-  if (shuttingDown) {
-    c.header("Retry-After", "1");
-    return c.json({ error: "Service is shutting down, retry on another instance" }, 503);
-  }
-  return next();
-});
-
-authenticated.use("*", authMiddleware(db));
-authenticated.use("*", rateLimitMiddleware(config.RATE_LIMIT_PER_MINUTE));
-
-// Route-specific rate limits (stricter than global)
-authenticated.use("/v1/settle", routeRateLimitMiddleware("settle", 50));
-authenticated.use("/v1/settle-direct", routeRateLimitMiddleware("settle", 50));
-authenticated.use("/v1/verify", routeRateLimitMiddleware("verify", 100));
-
-// OFAC compliance screening on settlement routes
-if (ofacProvider) {
-  authenticated.use("/v1/settle", complianceMiddleware(ofacProvider));
-  authenticated.use("/v1/settle-direct", complianceMiddleware(ofacProvider));
-}
-
-// Squads SPN spending limit validation (Solana payments only)
-const solanaRpcUrl = rpcUrls[solanaNetworks[0]] ?? "https://api.devnet.solana.com";
-authenticated.use("/v1/settle", squadsMiddleware({ db, rpcUrl: solanaRpcUrl }));
-authenticated.use("/v1/settle-direct", squadsMiddleware({ db, rpcUrl: solanaRpcUrl }));
-
-authenticated.route("/", createVerifyRoute(facilitator, { metrics }));
-authenticated.route("/", createSettleRoute(facilitator, db, {
-  koraEnabled,
+// ─── Hono App ───
+const app = buildApp({
+  config,
+  db,
+  facilitator,
   metrics,
-  solanaRpcUrl,
-  onSettle: () => {
-    confirmationWorker.nudge();
-    webhookRetryWorker.nudge();
-    onChainRecorderWorker?.nudge();
+  logger,
+  workers: {
+    confirmation: confirmationWorker,
+    webhookRetry: webhookRetryWorker,
+    onChainRecorder: onChainRecorderWorker,
   },
-}));
-if (anchorIntegration) {
-  authenticated.route("/", createSettleDirectRoute(db, {
-    program: anchorIntegration.program,
-    koraEnabled,
-  }));
-}
-authenticated.route("/", createStatusRoute(db));
-
-// CRUD + management routes (Phase 2/3)
-authenticated.use("/v1/paywalls", routeRateLimitMiddleware("paywalls-write", 30));
-authenticated.use("/v1/agents", routeRateLimitMiddleware("agents-write", 30));
-authenticated.use("/v1/webhooks", routeRateLimitMiddleware("webhooks", 30));
-authenticated.route("/", createPaywallRoutes(db));
-authenticated.route("/", createTransactionListRoute(db));
-authenticated.route("/", createAgentRoutes(db));
-authenticated.route("/", createWebhookRoutes(db));
-authenticated.route("/", createMerchantRoute(db));
-
-// CLI onboarding — authenticated endpoints (merchant management, api keys, sessions).
-// The cliAuthMiddleware below is scoped to "/v1/onboarding/*", NOT "*":
-// mounting in a sub-app does NOT scope a "*" use(); once mounted at "/" it
-// matches every path and 401s the pp_live_* api-key surface.
-//
-// IMPORTANT: must mount BEFORE `authenticated` because Hono evaluates merged
-// routes/middleware in registration order. `authenticated.use("*", authMiddleware)`
-// would otherwise intercept every onboarding request with `Missing API key`
-// before cliAuthMiddleware could see it.
-if (onboardingEnabled) {
-  const cliAuthenticated = new Hono<AppEnv>();
-  cliAuthenticated.use("*", async (c, next) => {
-    if (shuttingDown) {
-      c.header("Retry-After", "1");
-      return c.json({ error: "Service is shutting down, retry on another instance" }, 503);
-    }
-    return next();
-  });
-  // Scope to onboarding paths only. A bare "*" matches every request once this
-  // sub-app is mounted at "/", which 401s the whole pp_live_* api-key surface
-  // (/v1/settle, /v1/verify, etc.) with `missing_bearer_token`. Regression #130.
-  cliAuthenticated.use("/v1/onboarding/*", cliAuthMiddleware(db));
-  cliAuthenticated.route("/", createMerchantOnboardingRoute(db));
-  cliAuthenticated.route("/", createApiKeysOnboardingRoute(db));
-  cliAuthenticated.route("/", createSessionsOnboardingRoute(db));
-  cliAuthenticated.route("/", createOnboardingHealthRoute(db));
-  app.route("/", cliAuthenticated);
-}
-
-app.route("/", authenticated);
+  koraEnabled,
+  koraFeePayer,
+  anchorIntegration,
+  ofacProvider,
+  onboardingEnabled,
+  solanaRpcUrl,
+  supportedNetworks: allNetworks,
+  isShuttingDown: () => shuttingDown,
+});
 
 // ─── Start Server ───
 const port = config.PORT;
@@ -348,12 +222,6 @@ const server = serve({ fetch: app.fetch, port }, (info) => {
 
 // Graceful shutdown
 const SHUTDOWN_TIMEOUT_MS = config.SHUTDOWN_TIMEOUT_MS;
-let shuttingDown = false;
-
-/** Exposed for health route — returns true once SIGTERM/SIGINT received */
-export function isShuttingDown(): boolean {
-  return shuttingDown;
-}
 
 async function shutdown(signal: string) {
   if (shuttingDown) return; // Prevent double-shutdown

--- a/apps/facilitator/src/routes/supported.ts
+++ b/apps/facilitator/src/routes/supported.ts
@@ -1,12 +1,60 @@
 import { Hono } from "hono";
 import type { x402Facilitator } from "@x402/core/facilitator";
 
-export function createSupportedRoute(facilitator: x402Facilitator) {
+/**
+ * x402 v2 advertises networks by CAIP-2 id; the legacy v1 "exact" schemes
+ * advertise by short name and dump their entire built-in registry (every
+ * mainnet + testnet the scheme knows) regardless of what this facilitator is
+ * configured and funded for. Left unfiltered, /v1/supported tells an agent we
+ * settle on `ethereum`, `base`, `polygon`, `avalanche`, ... when this deploy is
+ * testnet-only. We intersect the advertised kinds with the configured networks:
+ * each configured CAIP-2 id matches the v2 kinds directly, and its v1 short-name
+ * alias(es) below match the v1 kinds.
+ *
+ * Fail-safe by construction: a configured network with no alias entry simply has
+ * its v1 kinds dropped (under-advertised), never the reverse — an unconfigured
+ * mainnet can never leak back in.
+ */
+const CAIP2_TO_X402_V1_NAMES: Record<string, string[]> = {
+  // Solana
+  "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": ["solana-devnet"], // devnet (default config)
+  // EVM (keyed by chain id; values are the @x402 v1 network names)
+  "eip155:84532": ["base-sepolia"],
+  "eip155:8453": ["base"],
+  "eip155:80002": ["polygon-amoy"],
+  "eip155:137": ["polygon"],
+};
+
+/**
+ * Build the set of network identifiers this facilitator should advertise:
+ * every configured CAIP-2 id plus its known x402-v1 short-name alias(es).
+ * Pure + exported for unit tests.
+ */
+export function allowedSupportedNetworks(configuredNetworks: string[]): Set<string> {
+  const allowed = new Set<string>();
+  for (const caip2 of configuredNetworks) {
+    allowed.add(caip2);
+    for (const v1Name of CAIP2_TO_X402_V1_NAMES[caip2] ?? []) {
+      allowed.add(v1Name);
+    }
+  }
+  return allowed;
+}
+
+export function createSupportedRoute(
+  facilitator: x402Facilitator,
+  options: { networks: string[] },
+) {
   const app = new Hono();
+  const allowed = allowedSupportedNetworks(options.networks);
 
   app.get("/v1/supported", (c) => {
     const supported = facilitator.getSupported();
-    return c.json(supported);
+    const filtered = {
+      ...supported,
+      kinds: supported.kinds.filter((k) => allowed.has(k.network)),
+    };
+    return c.json(filtered);
   });
 
   return app;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
       "@hono/node-server@<1.19.13": "1.19.13",
       "uuid@<14.0.0": "14.0.0",
       "fast-uri@<3.1.2": "3.1.2"
+    },
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-r5fr-rjxr-66jc"
+      ]
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Two changes from this session's hardening pass (the vitest bump is intentionally not included — see Notes).

### 1. Facilitator: `buildApp` factory + `/v1/supported` testnet scoping
- **`buildApp(deps)`** extracted from `index.ts` into `app.ts`. The route + middleware wiring — including the load-bearing cli-auth vs api-key mount order/scope (the #130/#149 trap) — is now importable and side-effect-free, so it can be tested directly. `index.ts` becomes a thin bootstrap (config, signers, workers, server, shutdown).
- **`/v1/supported` scoped to configured networks.** The x402 v1 schemes advertise their entire built-in registry (`ethereum`, `base`, `polygon`, `avalanche`, ...) regardless of what this deploy is funded for. It now filters advertised kinds to the configured CAIP-2 ids and their x402-v1 short-name aliases. Fail-safe: an unmapped network is under-advertised, never leaked. **Deploy impact:** live `/v1/supported` drops from ~24 advertised networks to the 4 real ones (Solana devnet + Base Sepolia, v1+v2). The dropped mainnets were always false advertising (no mainnet signers).
- **Tests:** `auth-routing.test.ts` now asserts the real `buildApp` (the exact wiring that regressed in #149 — the prior mirror test could not catch that); new `supported.test.ts`; e2e app builders updated to the new `createSupportedRoute` signature.

### 2. Accept unreachable lodash advisory
- `GHSA-r5fr-rjxr-66jc` (lodash `_.template`) is a build-only transitive (`apps/dashboard > recharts > lodash`); the sink is unreachable and no upstream fix exists (advisory cites `>=4.18.0`, never released). Suppressed via `pnpm.auditConfig.ignoreGhsas`, documented in `SECURITY.md`, permanent fix tracked in #154 (recharts v3 drops bundled lodash).

## Testing
- `pnpm --filter @pincerpay/facilitator typecheck` — clean.
- `pnpm --filter @pincerpay/facilitator test` — 67 passed (incl. rewired auth-routing + new supported tests, both e2e suites).

## Notes / not in this PR
- **vitest criticals (`GHSA-5xrq-8626-4rwp`, dev-only Vitest UI server) are NOT fixed here.** Bumping vitest needs a `pnpm install`, and locally that pollutes the lockfile with the gitignored `apps/marketing` subtree (`form-data@2.3.3`, `tough-cookie@2.5.0`, old vitest) — the `apps/*` workspace glob picks it up, while the committed lockfile has zero marketing refs. The clean fix belongs in CI/dependabot: PR #152 covers root + mcp; `packages/cli` + `packages/onboarding` still need it. Root-cause option: exclude `apps/marketing` from `pnpm-workspace.yaml` (it moved to a separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
